### PR TITLE
docs(readme): update Agent Skills Spec URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Over the past six months, through building and iterating on real agent systems, 
 
 ---
 
-> Works with **[Kode CLI](https://github.com/shareAI-lab/Kode)**, **Claude Code**, **Cursor**, and any agent supporting the [Agent Skills Spec](https://github.com/anthropics/agent-skills).
+> Works with **[Kode CLI](https://github.com/shareAI-lab/Kode)**, **Claude Code**, **Cursor**, and any agent supporting the [Agent Skills Spec](https://agentskills.io/specification).
 
 <img height="400" alt="demo" src="https://github.com/user-attachments/assets/0e1e31f8-064f-4908-92ce-121e2eb8d453" />
 
@@ -187,7 +187,7 @@ MODEL_ID=claude-sonnet-4-5-20250929  # Optional: Model selection
 |------------|-------------|
 | [Kode](https://github.com/shareAI-lab/Kode) | Production-ready open source agent CLI |
 | [shareAI-skills](https://github.com/shareAI-lab/shareAI-skills) | Production skills collection |
-| [Agent Skills Spec](https://github.com/anthropics/agent-skills) | Official specification |
+| [Agent Skills Spec](https://agentskills.io/specification) | Official specification |
 
 ## Philosophy
 

--- a/README_ja.md
+++ b/README_ja.md
@@ -20,7 +20,7 @@
 
 ---
 
-> **[Kode CLI](https://github.com/shareAI-lab/Kode)**、**Claude Code**、**Cursor**、および [Agent Skills Spec](https://github.com/anthropics/agent-skills) をサポートするすべてのエージェントで動作します。
+> **[Kode CLI](https://github.com/shareAI-lab/Kode)**、**Claude Code**、**Cursor**、および [Agent Skills Spec](https://agentskills.io/specification) をサポートするすべてのエージェントで動作します。
 
 <img height="400" alt="demo" src="https://github.com/user-attachments/assets/0e1e31f8-064f-4908-92ce-121e2eb8d453" />
 
@@ -187,7 +187,7 @@ MODEL_ID=claude-sonnet-4-5-20250929  # 任意：モデル選択
 |------------|------|
 | [Kode](https://github.com/shareAI-lab/Kode) | 本番対応のオープンソースエージェントCLI |
 | [shareAI-skills](https://github.com/shareAI-lab/shareAI-skills) | 本番用Skillsコレクション |
-| [Agent Skills Spec](https://github.com/anthropics/agent-skills) | 公式仕様 |
+| [Agent Skills Spec](https://agentskills.io/specification) | 公式仕様 |
 
 ## 設計思想
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -20,7 +20,7 @@
 
 ---
 
-> 兼容 **[Kode CLI](https://github.com/shareAI-lab/Kode)**、**Claude Code**、**Cursor**，以及任何支持 [Agent Skills Spec](https://github.com/anthropics/agent-skills) 的 Agent。
+> 兼容 **[Kode CLI](https://github.com/shareAI-lab/Kode)**、**Claude Code**、**Cursor**，以及任何支持 [Agent Skills Spec](https://agentskills.io/specification) 的 Agent。
 
 <img height="400" alt="demo" src="https://github.com/user-attachments/assets/0e1e31f8-064f-4908-92ce-121e2eb8d453" />
 
@@ -192,7 +192,7 @@ MODEL_ID=claude-sonnet-4-5-20250929  # 可选：模型选择
 |------|------|
 | [Kode](https://github.com/shareAI-lab/Kode) | 生产就绪的开源 Agent CLI |
 | [shareAI-skills](https://github.com/shareAI-lab/shareAI-skills) | 生产 Skills 集合 |
-| [Agent Skills Spec](https://github.com/anthropics/agent-skills) | 官方规范 |
+| [Agent Skills Spec](https://agentskills.io/specification) | 官方规范 |
 
 ## 设计哲学
 


### PR DESCRIPTION
Replace GitHub repository link with official specification website URL across all language variants. The original URL https://github.com/anthropics/agent-skills now returns 404.