### PR TITLE
fix: support nested skill directory structure in SkillLoader

### DIFF
--- a/agents/s05_skill_loading.py
+++ b/agents/s05_skill_loading.py
@@ -57,8 +57,8 @@ class SkillLoader:
     def _load_all(self):
         if not self.skills_dir.exists():
             return
-        for f in sorted(self.skills_dir.glob("*.md")):
-            name = f.stem
+        for f in sorted(self.skills_dir.rglob("SKILL.md")):
+            name = f.parent.name
             text = f.read_text()
             meta, body = self._parse_frontmatter(text)
             self.skills[name] = {"meta": meta, "body": body, "path": str(f)}


### PR DESCRIPTION
fix issue: #30 SKILLS 动态加载的实现示例存在覆盖问题，会导致重复加载名为 SKILL 的 skill
- Replace glob('*.md') with rglob('SKILL.md') to support subdirectory skills                                                                               
- Use f.parent.name as skill key instead of f.stem to avoid SKILL name collision
- Aligns with Anthropic skill directory convention: .claude/skills/<name>/SKILL.md