### PR TITLE
fix: redirect root path to default locale

### DIFF
--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -1,0 +1,5 @@
+import { redirect } from "next/navigation";
+
+export default function RootPage() {
+  redirect("/en");
+}


### PR DESCRIPTION
fix issues: #32 README中web模块说明不足，默认页面404
- Add root page.tsx that redirects / to /en
- Fixes 404 when accessing http://localhost:3000