### PR TITLE
fix(agents): print final assistant response in s_full

### DIFF
--- a/agents/s_full.py
+++ b/agents/s_full.py
@@ -732,4 +732,9 @@ if __name__ == "__main__":
             continue
         history.append({"role": "user", "content": query})
         agent_loop(history)
+        response_content = history[-1]["content"]
+        if isinstance(response_content, list):
+            for block in response_content:
+                if hasattr(block, "text"):
+                    print(block.text)
         print()


### PR DESCRIPTION
Fix missing response output in s_full.py main loop. All other agent files (s01-s12) already have this code to print the assistant's final response from history[-1]['content'].