### PR TITLE
fix(s08): flush background task results before agent loop exits

### DIFF
--- a/agents/s08_background_tasks.py
+++ b/agents/s08_background_tasks.py
@@ -27,6 +27,7 @@ Key insight: "Fire and forget -- the agent doesn't block while the command runs.
 import os
 import subprocess
 import threading
+import time
 import uuid
 from pathlib import Path
 
@@ -43,6 +44,8 @@ client = Anthropic(base_url=os.getenv("ANTHROPIC_BASE_URL"))
 MODEL = os.environ["MODEL_ID"]
 
 SYSTEM = f"You are a coding agent at {WORKDIR}. Use background_run for long-running commands."
+
+MAX_BG_WAIT = 30  # seconds to wait for still-running tasks before exiting
 
 
 # -- BackgroundManager: threaded execution + notification queue --
@@ -200,6 +203,25 @@ def agent_loop(messages: list):
         )
         messages.append({"role": "assistant", "content": response.content})
         if response.stop_reason != "tool_use":
+            # Flush results that completed while the LLM was responding.
+            # If tasks are still running, wait up to MAX_BG_WAIT for them.
+            pending = BG.drain_notifications()
+            if not pending:
+                still_running = [t for t in BG.tasks.values() if t["status"] == "running"]
+                if still_running:
+                    deadline = time.monotonic() + MAX_BG_WAIT
+                    while time.monotonic() < deadline:
+                        if not any(t["status"] == "running" for t in BG.tasks.values()):
+                            break
+                        time.sleep(0.5)
+                    pending = BG.drain_notifications()
+            if pending:
+                notif_text = "\n".join(
+                    f"[bg:{n['task_id']}] {n['status']}: {n['result']}" for n in pending
+                )
+                messages.append({"role": "user", "content": f"<background-results>\n{notif_text}\n</background-results>"})
+                messages.append({"role": "assistant", "content": "Noted background results."})
+                continue  # let the LLM see the late-arriving results
             return
         results = []
         for block in response.content:

--- a/agents/s_full.py
+++ b/agents/s_full.py
@@ -64,6 +64,7 @@ TRANSCRIPT_DIR = WORKDIR / ".transcripts"
 TOKEN_THRESHOLD = 100000
 POLL_INTERVAL = 5
 IDLE_TIMEOUT = 60
+MAX_BG_WAIT = 30  # seconds to wait for still-running tasks before exiting
 
 VALID_MSG_TYPES = {"message", "broadcast", "shutdown_request",
                    "shutdown_response", "plan_approval_response"}
@@ -677,6 +678,23 @@ def agent_loop(messages: list):
         )
         messages.append({"role": "assistant", "content": response.content})
         if response.stop_reason != "tool_use":
+            # Flush results that completed while the LLM was responding.
+            # If tasks are still running, wait up to MAX_BG_WAIT for them.
+            pending = BG.drain()
+            if not pending:
+                still_running = [t for t in BG.tasks.values() if t["status"] == "running"]
+                if still_running:
+                    deadline = time.monotonic() + MAX_BG_WAIT
+                    while time.monotonic() < deadline:
+                        if not any(t["status"] == "running" for t in BG.tasks.values()):
+                            break
+                        time.sleep(0.5)
+                    pending = BG.drain()
+            if pending:
+                txt = "\n".join(f"[bg:{n['task_id']}] {n['status']}: {n['result']}" for n in pending)
+                messages.append({"role": "user", "content": f"<background-results>\n{txt}\n</background-results>"})
+                messages.append({"role": "assistant", "content": "Noted background results."})
+                continue  # let the LLM see the late-arriving results
             return
         # Tool execution
         results = []


### PR DESCRIPTION
## Problem

Closes #46.

In `s08_background_tasks.py` (and `s_full.py`), the `agent_loop` exits immediately when `stop_reason != "tool_use"`. Any background task results that arrive **during** the final LLM call, or from tasks that are still running at that point, are silently dropped — the notification queue is never drained again.

Minimal reproduction:
1. Ask the agent to run a slow command in the background (`background_run("sleep 5 && echo done")`).
2. The LLM responds with "OK, running in the background" and returns `end_turn`.
3. The loop exits. When the task finishes 5 seconds later its result sits in the queue forever.

## Fix

At the exit branch (`stop_reason != "tool_use"`) in `agent_loop`, before returning:

1. **Immediate drain** — flush any results that completed while the LLM was generating its response.
2. **Wait loop** — if tasks are still running, poll up to `MAX_BG_WAIT` (30 s) for them to finish, then drain again.
3. **Re-enter loop** — if there are pending results, inject them as a `<background-results>` message and `continue` so the LLM can acknowledge them before the session ends.

```python
if response.stop_reason != "tool_use":
    pending = BG.drain_notifications()
    if not pending:
        still_running = [t for t in BG.tasks.values() if t["status"] == "running"]
        if still_running:
            deadline = time.monotonic() + MAX_BG_WAIT
            while time.monotonic() < deadline:
                if not any(t["status"] == "running" for t in BG.tasks.values()):
                    break
                time.sleep(0.5)
            pending = BG.drain_notifications()
    if pending:
        notif_text = "\n".join(...)
        messages.append(...)
        continue  # let the LLM see the late-arriving results
    return
```

The same fix is applied to `s_full.py` where `BackgroundManager` is also used.

## Files changed

| File | Change |
|------|--------|
| `agents/s08_background_tasks.py` | Add `import time`, `MAX_BG_WAIT` constant, final-drain logic in `agent_loop` |
| `agents/s_full.py` | Add `MAX_BG_WAIT` constant, same final-drain logic in `agent_loop` |