### PR TITLE
Fix: Add missing AI response output in s_full.py main loop

### DIFF
--- a/agents/s_full.py
+++ b/agents/s_full.py
@@ -732,4 +732,9 @@ if __name__ == "__main__":
             continue
         history.append({"role": "user", "content": query})
         agent_loop(history)
+        response_content = history[-1]["content"]
+        if isinstance(response_content, list):
+            for block in response_content:
+                if hasattr(block, "text"):
+                    print(block.text)
         print()


### PR DESCRIPTION
### Description
When running `s_full.py`, the program executes successfully, but the AI's response is not explicitly printed to the console. This makes it difficult to see the actual output of the agent loop.

### Changes Made
Added code to print the AI's response immediately after the `agent_loop(history)` call in the main loop of `s_full.py`.

### Impact
Users can now clearly see the agent's responses in the terminal during execution, making the reference agent behave as expected.