### PR TITLE
fix(agents): add UTF-8 encoding to subprocess calls for cross-platform compatibility

### DIFF
--- a/agents/s01_agent_loop.py
+++ b/agents/s01_agent_loop.py
@@ -56,7 +56,8 @@ def run_bash(command: str) -> str:
         return "Error: Dangerous command blocked"
     try:
         r = subprocess.run(command, shell=True, cwd=os.getcwd(),
-                           capture_output=True, text=True, timeout=120)
+                           capture_output=True, text=True,
+                           encoding='utf-8', errors='replace', timeout=120)
         out = (r.stdout + r.stderr).strip()
         return out[:50000] if out else "(no output)"
     except subprocess.TimeoutExpired:
@@ -72,6 +73,7 @@ def agent_loop(messages: list):
         )
         # Append assistant turn
         messages.append({"role": "assistant", "content": response.content})
+        
         # If the model didn't call a tool, we're done
         if response.stop_reason != "tool_use":
             return

--- a/agents/s02_tool_use.py
+++ b/agents/s02_tool_use.py
@@ -50,7 +50,8 @@ def run_bash(command: str) -> str:
         return "Error: Dangerous command blocked"
     try:
         r = subprocess.run(command, shell=True, cwd=WORKDIR,
-                           capture_output=True, text=True, timeout=120)
+                           capture_output=True, text=True,
+                           encoding='utf-8', errors='replace', timeout=120)
         out = (r.stdout + r.stderr).strip()
         return out[:50000] if out else "(no output)"
     except subprocess.TimeoutExpired:
@@ -117,6 +118,7 @@ def agent_loop(messages: list):
             tools=TOOLS, max_tokens=8000,
         )
         messages.append({"role": "assistant", "content": response.content})
+
         if response.stop_reason != "tool_use":
             return
         results = []

--- a/agents/s03_todo_write.py
+++ b/agents/s03_todo_write.py
@@ -101,7 +101,8 @@ def run_bash(command: str) -> str:
         return "Error: Dangerous command blocked"
     try:
         r = subprocess.run(command, shell=True, cwd=WORKDIR,
-                           capture_output=True, text=True, timeout=120)
+                           capture_output=True, text=True,
+                           encoding='utf-8', errors='replace', timeout=120)
         out = (r.stdout + r.stderr).strip()
         return out[:50000] if out else "(no output)"
     except subprocess.TimeoutExpired:

--- a/agents/s04_subagent.py
+++ b/agents/s04_subagent.py
@@ -55,7 +55,8 @@ def run_bash(command: str) -> str:
         return "Error: Dangerous command blocked"
     try:
         r = subprocess.run(command, shell=True, cwd=WORKDIR,
-                           capture_output=True, text=True, timeout=120)
+                           capture_output=True, text=True,
+                           encoding='utf-8', errors='replace', timeout=120)
         out = (r.stdout + r.stderr).strip()
         return out[:50000] if out else "(no output)"
     except subprocess.TimeoutExpired:

--- a/agents/s05_skill_loading.py
+++ b/agents/s05_skill_loading.py
@@ -126,7 +126,8 @@ def run_bash(command: str) -> str:
         return "Error: Dangerous command blocked"
     try:
         r = subprocess.run(command, shell=True, cwd=WORKDIR,
-                           capture_output=True, text=True, timeout=120)
+                           capture_output=True, text=True,
+                           encoding='utf-8', errors='replace', timeout=120)
         out = (r.stdout + r.stderr).strip()
         return out[:50000] if out else "(no output)"
     except subprocess.TimeoutExpired:

--- a/agents/s06_context_compact.py
+++ b/agents/s06_context_compact.py
@@ -133,7 +133,8 @@ def run_bash(command: str) -> str:
         return "Error: Dangerous command blocked"
     try:
         r = subprocess.run(command, shell=True, cwd=WORKDIR,
-                           capture_output=True, text=True, timeout=120)
+                           capture_output=True, text=True,
+                           encoding='utf-8', errors='replace', timeout=120)
         out = (r.stdout + r.stderr).strip()
         return out[:50000] if out else "(no output)"
     except subprocess.TimeoutExpired:

--- a/agents/s07_task_system.py
+++ b/agents/s07_task_system.py
@@ -139,7 +139,8 @@ def run_bash(command: str) -> str:
         return "Error: Dangerous command blocked"
     try:
         r = subprocess.run(command, shell=True, cwd=WORKDIR,
-                           capture_output=True, text=True, timeout=120)
+                           capture_output=True, text=True,
+                           encoding='utf-8', errors='replace', timeout=120)
         out = (r.stdout + r.stderr).strip()
         return out[:50000] if out else "(no output)"
     except subprocess.TimeoutExpired:

--- a/agents/s08_background_tasks.py
+++ b/agents/s08_background_tasks.py
@@ -67,7 +67,8 @@ class BackgroundManager:
         try:
             r = subprocess.run(
                 command, shell=True, cwd=WORKDIR,
-                capture_output=True, text=True, timeout=300
+                capture_output=True, text=True,
+                encoding='utf-8', errors='replace', timeout=300
             )
             output = (r.stdout + r.stderr).strip()[:50000]
             status = "completed"
@@ -123,7 +124,8 @@ def run_bash(command: str) -> str:
         return "Error: Dangerous command blocked"
     try:
         r = subprocess.run(command, shell=True, cwd=WORKDIR,
-                           capture_output=True, text=True, timeout=120)
+                           capture_output=True, text=True,
+                           encoding='utf-8', errors='replace', timeout=120)
         out = (r.stdout + r.stderr).strip()
         return out[:50000] if out else "(no output)"
     except subprocess.TimeoutExpired:

--- a/agents/s09_agent_teams.py
+++ b/agents/s09_agent_teams.py
@@ -265,7 +265,8 @@ def _run_bash(command: str) -> str:
     try:
         r = subprocess.run(
             command, shell=True, cwd=WORKDIR,
-            capture_output=True, text=True, timeout=120,
+            capture_output=True, text=True,
+            encoding='utf-8', errors='replace', timeout=120,
         )
         out = (r.stdout + r.stderr).strip()
         return out[:50000] if out else "(no output)"

--- a/agents/s10_team_protocols.py
+++ b/agents/s10_team_protocols.py
@@ -306,7 +306,8 @@ def _run_bash(command: str) -> str:
     try:
         r = subprocess.run(
             command, shell=True, cwd=WORKDIR,
-            capture_output=True, text=True, timeout=120,
+            capture_output=True, text=True,
+            encoding='utf-8', errors='replace', timeout=120,
         )
         out = (r.stdout + r.stderr).strip()
         return out[:50000] if out else "(no output)"

--- a/agents/s11_autonomous_agents.py
+++ b/agents/s11_autonomous_agents.py
@@ -384,7 +384,8 @@ def _run_bash(command: str) -> str:
     try:
         r = subprocess.run(
             command, shell=True, cwd=WORKDIR,
-            capture_output=True, text=True, timeout=120,
+            capture_output=True, text=True,
+            encoding='utf-8', errors='replace', timeout=120,
         )
         out = (r.stdout + r.stderr).strip()
         return out[:50000] if out else "(no output)"

--- a/agents/s12_worktree_task_isolation.py
+++ b/agents/s12_worktree_task_isolation.py
@@ -57,6 +57,8 @@ def detect_repo_root(cwd: Path) -> Path | None:
             cwd=cwd,
             capture_output=True,
             text=True,
+            encoding='utf-8',
+            errors='replace',
             timeout=10,
         )
         if r.returncode != 0:
@@ -240,6 +242,8 @@ class WorktreeManager:
                 cwd=self.repo_root,
                 capture_output=True,
                 text=True,
+                encoding='utf-8',
+                errors='replace',
                 timeout=10,
             )
             return r.returncode == 0
@@ -254,6 +258,8 @@ class WorktreeManager:
             cwd=self.repo_root,
             capture_output=True,
             text=True,
+            encoding='utf-8',
+            errors='replace',
             timeout=120,
         )
         if r.returncode != 0:
@@ -359,6 +365,8 @@ class WorktreeManager:
             cwd=path,
             capture_output=True,
             text=True,
+            encoding='utf-8',
+            errors='replace',
             timeout=60,
         )
         text = (r.stdout + r.stderr).strip()
@@ -383,6 +391,8 @@ class WorktreeManager:
                 cwd=path,
                 capture_output=True,
                 text=True,
+                encoding='utf-8',
+                errors='replace',
                 timeout=300,
             )
             out = (r.stdout + r.stderr).strip()
@@ -492,6 +502,8 @@ def run_bash(command: str) -> str:
             cwd=WORKDIR,
             capture_output=True,
             text=True,
+            encoding='utf-8',
+            errors='replace',
             timeout=120,
         )
         out = (r.stdout + r.stderr).strip()

--- a/agents/s_full.py
+++ b/agents/s_full.py
@@ -82,7 +82,8 @@ def run_bash(command: str) -> str:
         return "Error: Dangerous command blocked"
     try:
         r = subprocess.run(command, shell=True, cwd=WORKDIR,
-                           capture_output=True, text=True, timeout=120)
+                           capture_output=True, text=True,
+                           encoding='utf-8', errors='replace', timeout=120)
         out = (r.stdout + r.stderr).strip()
         return out[:50000] if out else "(no output)"
     except subprocess.TimeoutExpired:
@@ -339,7 +340,8 @@ class BackgroundManager:
     def _exec(self, tid: str, command: str, timeout: int):
         try:
             r = subprocess.run(command, shell=True, cwd=WORKDIR,
-                               capture_output=True, text=True, timeout=timeout)
+                               capture_output=True, text=True,
+                               encoding='utf-8', errors='replace', timeout=timeout)
             output = (r.stdout + r.stderr).strip()[:50000]
             self.tasks[tid].update({"status": "completed", "result": output or "(no output)"})
         except Exception as e:


### PR DESCRIPTION
**Description**
When run in Chinese Windows 11 system, it will encounter the following error:
```
 Exception in thread Thread-3 (_readerthread):
  Traceback (most recent call last):
    File "D:\miniconda\Lib\threading.py", line 1038, in _bootstrap_inner
      self.run()
    File "D:\miniconda\Lib\threading.py", line 975, in run
      self._target(*self._args, **self._kwargs)
    File "D:\miniconda\Lib\subprocess.py", line 1597, in _readerthread
      buffer.append(fh.read())
                    ^^^^^^^^^
  UnicodeDecodeError: 'gbk' codec can't decode byte 0x88 in position 46: illegal multibyte sequence
  Traceback (most recent call last):
    File "D:\apps\learn-claude-code\agents\s01_agent_loop.py", line 102, in <module>
      agent_loop(history)
```

**Changes Made**
Add encoding='utf-8' and errors='replace' parameters to all subprocess.run calls in agents scripts to fix UnicodeDecodeError on Windows systems.

**Impact**
This ensures consistent behavior across Windows (which defaults to GBK/CP936) and Linux (which defaults to UTF-8) by explicitly specifying UTF-8 encoding and replacing undecodable bytes instead of raising exceptions.