### PR TITLE
fix(agents): support Ollama and other OpenAI-compatible APIs

### DIFF
--- a/agents/s01_agent_loop.py
+++ b/agents/s01_agent_loop.py
@@ -31,8 +31,8 @@ from dotenv import load_dotenv
 
 load_dotenv(override=True)
 
-if os.getenv("ANTHROPIC_BASE_URL"):
-    os.environ.pop("ANTHROPIC_AUTH_TOKEN", None)
+# Note: For Ollama or other OpenAI-compatible APIs, 
+# set ANTHROPIC_AUTH_TOKEN to any non-empty value (e.g., "ollama")
 
 client = Anthropic(base_url=os.getenv("ANTHROPIC_BASE_URL"))
 MODEL = os.environ["MODEL_ID"]

--- a/agents/s02_tool_use.py
+++ b/agents/s02_tool_use.py
@@ -27,8 +27,8 @@ from dotenv import load_dotenv
 
 load_dotenv(override=True)
 
-if os.getenv("ANTHROPIC_BASE_URL"):
-    os.environ.pop("ANTHROPIC_AUTH_TOKEN", None)
+# Note: For Ollama or other OpenAI-compatible APIs, 
+# set ANTHROPIC_AUTH_TOKEN to any non-empty value (e.g., "ollama")
 
 WORKDIR = Path.cwd()
 client = Anthropic(base_url=os.getenv("ANTHROPIC_BASE_URL"))

--- a/agents/s03_todo_write.py
+++ b/agents/s03_todo_write.py
@@ -35,8 +35,8 @@ from dotenv import load_dotenv
 
 load_dotenv(override=True)
 
-if os.getenv("ANTHROPIC_BASE_URL"):
-    os.environ.pop("ANTHROPIC_AUTH_TOKEN", None)
+# Note: For Ollama or other OpenAI-compatible APIs, 
+# set ANTHROPIC_AUTH_TOKEN to any non-empty value (e.g., "ollama")
 
 WORKDIR = Path.cwd()
 client = Anthropic(base_url=os.getenv("ANTHROPIC_BASE_URL"))

--- a/agents/s04_subagent.py
+++ b/agents/s04_subagent.py
@@ -31,8 +31,8 @@ from dotenv import load_dotenv
 
 load_dotenv(override=True)
 
-if os.getenv("ANTHROPIC_BASE_URL"):
-    os.environ.pop("ANTHROPIC_AUTH_TOKEN", None)
+# Note: For Ollama or other OpenAI-compatible APIs, 
+# set ANTHROPIC_AUTH_TOKEN to any non-empty value (e.g., "ollama")
 
 WORKDIR = Path.cwd()
 client = Anthropic(base_url=os.getenv("ANTHROPIC_BASE_URL"))

--- a/agents/s05_skill_loading.py
+++ b/agents/s05_skill_loading.py
@@ -44,8 +44,8 @@ from dotenv import load_dotenv
 
 load_dotenv(override=True)
 
-if os.getenv("ANTHROPIC_BASE_URL"):
-    os.environ.pop("ANTHROPIC_AUTH_TOKEN", None)
+# Note: For Ollama or other OpenAI-compatible APIs, 
+# set ANTHROPIC_AUTH_TOKEN to any non-empty value (e.g., "ollama")
 
 WORKDIR = Path.cwd()
 client = Anthropic(base_url=os.getenv("ANTHROPIC_BASE_URL"))

--- a/agents/s06_context_compact.py
+++ b/agents/s06_context_compact.py
@@ -44,8 +44,8 @@ from dotenv import load_dotenv
 
 load_dotenv(override=True)
 
-if os.getenv("ANTHROPIC_BASE_URL"):
-    os.environ.pop("ANTHROPIC_AUTH_TOKEN", None)
+# Note: For Ollama or other OpenAI-compatible APIs, 
+# set ANTHROPIC_AUTH_TOKEN to any non-empty value (e.g., "ollama")
 
 WORKDIR = Path.cwd()
 client = Anthropic(base_url=os.getenv("ANTHROPIC_BASE_URL"))

--- a/agents/s07_task_system.py
+++ b/agents/s07_task_system.py
@@ -31,8 +31,8 @@ from dotenv import load_dotenv
 
 load_dotenv(override=True)
 
-if os.getenv("ANTHROPIC_BASE_URL"):
-    os.environ.pop("ANTHROPIC_AUTH_TOKEN", None)
+# Note: For Ollama or other OpenAI-compatible APIs, 
+# set ANTHROPIC_AUTH_TOKEN to any non-empty value (e.g., "ollama")
 
 WORKDIR = Path.cwd()
 client = Anthropic(base_url=os.getenv("ANTHROPIC_BASE_URL"))

--- a/agents/s08_background_tasks.py
+++ b/agents/s08_background_tasks.py
@@ -35,8 +35,8 @@ from dotenv import load_dotenv
 
 load_dotenv(override=True)
 
-if os.getenv("ANTHROPIC_BASE_URL"):
-    os.environ.pop("ANTHROPIC_AUTH_TOKEN", None)
+# Note: For Ollama or other OpenAI-compatible APIs, 
+# set ANTHROPIC_AUTH_TOKEN to any non-empty value (e.g., "ollama")
 
 WORKDIR = Path.cwd()
 client = Anthropic(base_url=os.getenv("ANTHROPIC_BASE_URL"))

--- a/agents/s09_agent_teams.py
+++ b/agents/s09_agent_teams.py
@@ -53,8 +53,8 @@ from anthropic import Anthropic
 from dotenv import load_dotenv
 
 load_dotenv(override=True)
-if os.getenv("ANTHROPIC_BASE_URL"):
-    os.environ.pop("ANTHROPIC_AUTH_TOKEN", None)
+# Note: For Ollama or other OpenAI-compatible APIs, 
+# set ANTHROPIC_AUTH_TOKEN to any non-empty value (e.g., "ollama")
 
 WORKDIR = Path.cwd()
 client = Anthropic(base_url=os.getenv("ANTHROPIC_BASE_URL"))

--- a/agents/s10_team_protocols.py
+++ b/agents/s10_team_protocols.py
@@ -58,8 +58,8 @@ from anthropic import Anthropic
 from dotenv import load_dotenv
 
 load_dotenv(override=True)
-if os.getenv("ANTHROPIC_BASE_URL"):
-    os.environ.pop("ANTHROPIC_AUTH_TOKEN", None)
+# Note: For Ollama or other OpenAI-compatible APIs, 
+# set ANTHROPIC_AUTH_TOKEN to any non-empty value (e.g., "ollama")
 
 WORKDIR = Path.cwd()
 client = Anthropic(base_url=os.getenv("ANTHROPIC_BASE_URL"))

--- a/agents/s11_autonomous_agents.py
+++ b/agents/s11_autonomous_agents.py
@@ -46,8 +46,8 @@ from anthropic import Anthropic
 from dotenv import load_dotenv
 
 load_dotenv(override=True)
-if os.getenv("ANTHROPIC_BASE_URL"):
-    os.environ.pop("ANTHROPIC_AUTH_TOKEN", None)
+# Note: For Ollama or other OpenAI-compatible APIs, 
+# set ANTHROPIC_AUTH_TOKEN to any non-empty value (e.g., "ollama")
 
 WORKDIR = Path.cwd()
 client = Anthropic(base_url=os.getenv("ANTHROPIC_BASE_URL"))

--- a/agents/s12_worktree_task_isolation.py
+++ b/agents/s12_worktree_task_isolation.py
@@ -41,8 +41,8 @@ from dotenv import load_dotenv
 
 load_dotenv(override=True)
 
-if os.getenv("ANTHROPIC_BASE_URL"):
-    os.environ.pop("ANTHROPIC_AUTH_TOKEN", None)
+# Note: For Ollama or other OpenAI-compatible APIs, 
+# set ANTHROPIC_AUTH_TOKEN to any non-empty value (e.g., "ollama")
 
 WORKDIR = Path.cwd()
 client = Anthropic(base_url=os.getenv("ANTHROPIC_BASE_URL"))

--- a/agents/s_full.py
+++ b/agents/s_full.py
@@ -49,8 +49,8 @@ from anthropic import Anthropic
 from dotenv import load_dotenv
 
 load_dotenv(override=True)
-if os.getenv("ANTHROPIC_BASE_URL"):
-    os.environ.pop("ANTHROPIC_AUTH_TOKEN", None)
+# Note: For Ollama or other OpenAI-compatible APIs, 
+# set ANTHROPIC_AUTH_TOKEN to any non-empty value (e.g., "ollama")
 
 WORKDIR = Path.cwd()
 client = Anthropic(base_url=os.getenv("ANTHROPIC_BASE_URL"))


### PR DESCRIPTION
Fixes #59

## Problem
The code was removing `ANTHROPIC_AUTH_TOKEN` when a custom `ANTHROPIC_BASE_URL` was set, which broke Ollama compatibility.

Ollama requires a non-empty auth token (any value works, e.g., `ollama`).

## Fix
Removed the token removal logic and added documentation comment.

## Usage with Ollama
```env
ANTHROPIC_AUTH_TOKEN=ollama
ANTHROPIC_API_KEY=""
ANTHROPIC_BASE_URL=http://localhost:11434
MODEL_ID=qwen3-coder
```

## Files Changed
All 13 agent files in `agents/` directory.