### PR TITLE
Fix: Prevent Anthropic 400 BadRequest by appending nag reminder after tool results in s03

### DIFF
--- a/agents/s03_todo_write.py
+++ b/agents/s03_todo_write.py
@@ -186,7 +186,7 @@ def agent_loop(messages: list):
                     used_todo = True
         rounds_since_todo = 0 if used_todo else rounds_since_todo + 1
         if rounds_since_todo >= 3:
-            results.insert(0, {"type": "text", "text": "<reminder>Update your todos.</reminder>"})
+            results.append({"type": "text", "text": "<reminder>Update your todos.</reminder>"})
         messages.append({"role": "user", "content": results})
 
 


### PR DESCRIPTION
## Description
This PR fixes a critical crash in `s03_todo_write.py` caused by a strict sequence validation error from the Anthropic API when the "nag reminder" is injected.

## The Bug
When the agent runs for 3 rounds without using the `todo` tool, the script injects a nag reminder `<reminder>Update your todos.</reminder>` into the `results` list. 

Currently, it uses `results.insert(0, ...)` to place this text block at the very beginning of the `content` array. This causes the Anthropic API to throw a `400 BadRequest` error because it expects the `tool_result` block to immediately correspond to the `tool_use` block from the previous turn.

**Error Traceback:**
`anthropic.BadRequestError: Error code: 400 - ... "messages.20: tool_use ids were found without tool_result blocks immediately after... Each tool_use block must have a corresponding tool_result block in the next message."`

## Root Cause & Fix
Anthropic's API strictly enforces that responses to tool uses must contain the correct `tool_result` blocks. Injecting a text block at index `0` breaks this validation. 

The fix is straightforward: change `results.insert(0, ...)` to `results.append(...)`. 
This ensures that the required `tool_result` blocks are processed first, satisfying the API's constraints, and the text reminder is safely appended to the end of the user's message.

## Changes
- In `s03_todo_write.py`, modified the reminder injection logic from `results.insert(0, ...)` to `results.append(...)`.

## Testing
Tested locally. The agent now successfully receives the nag reminder after 3 rounds without crashing, and properly updates its Todo list in the subsequent turn.