### PR TITLE
fix: improve environment variable checking logic

### DIFF
--- a/agents/s01_agent_loop.py
+++ b/agents/s01_agent_loop.py
@@ -31,7 +31,7 @@ from dotenv import load_dotenv
 
 load_dotenv(override=True)
 
-if os.getenv("ANTHROPIC_BASE_URL"):
+if os.getenv("ANTHROPIC_BASE_URL") is not None:
     os.environ.pop("ANTHROPIC_AUTH_TOKEN", None)
 
 client = Anthropic(base_url=os.getenv("ANTHROPIC_BASE_URL"))


### PR DESCRIPTION
## Summary
- Use 'is not None' instead of truthy check for ANTHROPIC_BASE_URL
- This correctly handles cases where the env var is set to empty string
- Ensures ANTHROPIC_AUTH_TOKEN is properly cleared when using custom base URL

## Testing
- [ ] Works correctly with ANTHROPIC_BASE_URL set to empty string
- [ ] Works correctly with ANTHROPIC_BASE_URL not set