### PR TITLE
fix(i18n): correct Chinese label for memory layer — 内存管理 → 记忆管理

### DIFF
--- a/web/src/i18n/messages/zh.json
+++ b/web/src/i18n/messages/zh.json
@@ -55,7 +55,7 @@
   "layer_labels": {
     "tools": "工具与执行",
     "planning": "规划与协调",
-    "memory": "内存管理",
+    "memory": "记忆管理",
     "concurrency": "并发",
     "collaboration": "协作"
   },


### PR DESCRIPTION
layer_labels.memory was translated as "内存管理" (computer RAM), but the context is Agent memory/context retention — the correct term is "记忆管理".