### PR TITLE
Fix running background status in s_full

### DIFF
--- a/agents/s_full.py
+++ b/agents/s_full.py
@@ -350,7 +350,7 @@ class BackgroundManager:
     def check(self, tid: str = None) -> str:
         if tid:
             t = self.tasks.get(tid)
-            return f"[{t['status']}] {t.get('result', '(running)')}" if t else f"Unknown: {tid}"
+            return f"[{t['status']}] {t.get('result') or '(running)'}" if t else f"Unknown: {tid}"
         return "\n".join(f"{k}: [{v['status']}] {v['command'][:60]}" for k, v in self.tasks.items()) or "No bg tasks."
 
     def drain(self) -> list:

--- a/tests/test_s_full_background.py
+++ b/tests/test_s_full_background.py
@@ -1,0 +1,67 @@
+import importlib.util
+import os
+import sys
+import tempfile
+import types
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+MODULE_PATH = REPO_ROOT / "agents" / "s_full.py"
+
+
+def load_s_full_module(temp_cwd: Path):
+    fake_anthropic = types.ModuleType("anthropic")
+
+    class FakeAnthropic:
+        def __init__(self, *args, **kwargs):
+            self.messages = types.SimpleNamespace(create=None)
+
+    fake_dotenv = types.ModuleType("dotenv")
+    setattr(fake_anthropic, "Anthropic", FakeAnthropic)
+    setattr(fake_dotenv, "load_dotenv", lambda override=True: None)
+
+    previous_anthropic = sys.modules.get("anthropic")
+    previous_dotenv = sys.modules.get("dotenv")
+    previous_cwd = Path.cwd()
+    spec = importlib.util.spec_from_file_location("s_full_under_test", MODULE_PATH)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Unable to load {MODULE_PATH}")
+    module = importlib.util.module_from_spec(spec)
+
+    sys.modules["anthropic"] = fake_anthropic
+    sys.modules["dotenv"] = fake_dotenv
+    try:
+        os.chdir(temp_cwd)
+        os.environ.setdefault("MODEL_ID", "test-model")
+        spec.loader.exec_module(module)
+        return module
+    finally:
+        os.chdir(previous_cwd)
+        if previous_anthropic is None:
+            sys.modules.pop("anthropic", None)
+        else:
+            sys.modules["anthropic"] = previous_anthropic
+        if previous_dotenv is None:
+            sys.modules.pop("dotenv", None)
+        else:
+            sys.modules["dotenv"] = previous_dotenv
+
+
+class BackgroundManagerTests(unittest.TestCase):
+    def test_check_returns_running_placeholder_when_result_is_none(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            module = load_s_full_module(Path(tmp))
+            manager = module.BackgroundManager()
+            manager.tasks["abc123"] = {
+                "status": "running",
+                "command": "sleep 1",
+                "result": None,
+            }
+
+            self.assertEqual(manager.check("abc123"), "[running] (running)")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- report `(running)` instead of `None` when `BackgroundManager.check(task_id)` is called before a background task has produced a result
- add a focused `s_full` regression test that loads the capstone agent in isolation and verifies the running-task status string
- keep the patch scoped to `agents/s_full.py`, away from the existing README/background-task/read-file/template PR lines

## Validation

- `python3 -m py_compile agents/s_full.py tests/test_s_full_background.py`
- `python3 -m unittest discover -s tests -p "test_s_full_background.py"`

## Notes

- `agents/s_full.py` still carries pre-existing typing noise from the full reference agent; this PR only fixes the background status contract and its new targeted regression