### PR TITLE
fix(web): resolve hydration mismatch in dark mode toggle

### DIFF
--- a/web/src/components/layout/header.tsx
+++ b/web/src/components/layout/header.tsx
@@ -4,7 +4,7 @@ import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { useTranslations, useLocale } from "@/lib/i18n";
 import { Github, Menu, X, Sun, Moon } from "lucide-react";
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { cn } from "@/lib/utils";
 
 const NAV_ITEMS = [
@@ -24,14 +24,14 @@ export function Header() {
   const pathname = usePathname();
   const locale = useLocale();
   const [mobileOpen, setMobileOpen] = useState(false);
-  const [dark, setDark] = useState(() => {
-    if (typeof window !== "undefined") {
-      const stored = localStorage.getItem("theme");
-      if (stored) return stored === "dark";
-      return window.matchMedia("(prefers-color-scheme: dark)").matches;
-    }
-    return false;
-  });
+  const [dark, setDark] = useState(false);
+
+  useEffect(() => {
+    const stored = localStorage.getItem("theme");
+    const isDark = stored ? stored === "dark" : window.matchMedia("(prefers-color-scheme: dark)").matches;
+    setDark(isDark);
+    document.documentElement.classList.toggle("dark", isDark);
+  }, []);
 
   function toggleDark() {
     const next = !dark;


### PR DESCRIPTION
## Summary

- Fix React hydration error in `Header` component caused by dark mode state diverging between server and client
- `useState` initializer used `typeof window !== 'undefined'` branch which returns `false` on server but may return `true` on client (via `localStorage` / `matchMedia`), causing SSR HTML (Moon icon) to mismatch client (Sun icon)
- Replace with static `useState(false)` + `useEffect` to defer theme detection until after hydration

## Test plan

- [ ] Run `cd web && npm run dev`, open in browser with dark mode system preference
- [ ] Verify no hydration error in console
- [ ] Verify dark/light toggle still works correctly
- [ ] Verify theme persists across page refresh (localStorage)

🤖 Generated with [Claude Code](https://claude.com/claude-code)