### PR TITLE
fix(agents): bind readline arrow keys for libedit

### DIFF
--- a/agents/s01_agent_loop.py
+++ b/agents/s01_agent_loop.py
@@ -93,11 +93,10 @@ def agent_loop(messages: list):
 
 
 if __name__ == "__main__":
-    if readline and "libedit" in (readline.__doc__ or ""):
-        readline.parse_and_bind("bind ^[[A ed-prev-history")
-        readline.parse_and_bind("bind ^[[B ed-next-history")
-        readline.parse_and_bind("bind ^[[C em-next-char")
-        readline.parse_and_bind("bind ^[[D ed-prev-char")
+    readline.parse_and_bind("bind ^[[A ed-prev-history")
+    readline.parse_and_bind("bind ^[[B ed-next-history")
+    readline.parse_and_bind("bind ^[[C em-next-char")
+    readline.parse_and_bind("bind ^[[D ed-prev-char")
     history = []
     while True:
         try:

--- a/agents/s02_tool_use.py
+++ b/agents/s02_tool_use.py
@@ -135,11 +135,10 @@ def agent_loop(messages: list):
 
 
 if __name__ == "__main__":
-    if readline and "libedit" in (readline.__doc__ or ""):
-        readline.parse_and_bind("bind ^[[A ed-prev-history")
-        readline.parse_and_bind("bind ^[[B ed-next-history")
-        readline.parse_and_bind("bind ^[[C em-next-char")
-        readline.parse_and_bind("bind ^[[D ed-prev-char")
+    readline.parse_and_bind("bind ^[[A ed-prev-history")
+    readline.parse_and_bind("bind ^[[B ed-next-history")
+    readline.parse_and_bind("bind ^[[C em-next-char")
+    readline.parse_and_bind("bind ^[[D ed-prev-char")
     history = []
     while True:
         try:

--- a/agents/s03_todo_write.py
+++ b/agents/s03_todo_write.py
@@ -196,11 +196,10 @@ def agent_loop(messages: list):
 
 
 if __name__ == "__main__":
-    if readline and "libedit" in (readline.__doc__ or ""):
-        readline.parse_and_bind("bind ^[[A ed-prev-history")
-        readline.parse_and_bind("bind ^[[B ed-next-history")
-        readline.parse_and_bind("bind ^[[C em-next-char")
-        readline.parse_and_bind("bind ^[[D ed-prev-char")
+    readline.parse_and_bind("bind ^[[A ed-prev-history")
+    readline.parse_and_bind("bind ^[[B ed-next-history")
+    readline.parse_and_bind("bind ^[[C em-next-char")
+    readline.parse_and_bind("bind ^[[D ed-prev-char")
     history = []
     while True:
         try:

--- a/agents/s04_subagent.py
+++ b/agents/s04_subagent.py
@@ -170,11 +170,10 @@ def agent_loop(messages: list):
 
 
 if __name__ == "__main__":
-    if readline and "libedit" in (readline.__doc__ or ""):
-        readline.parse_and_bind("bind ^[[A ed-prev-history")
-        readline.parse_and_bind("bind ^[[B ed-next-history")
-        readline.parse_and_bind("bind ^[[C em-next-char")
-        readline.parse_and_bind("bind ^[[D ed-prev-char")
+    readline.parse_and_bind("bind ^[[A ed-prev-history")
+    readline.parse_and_bind("bind ^[[B ed-next-history")
+    readline.parse_and_bind("bind ^[[C em-next-char")
+    readline.parse_and_bind("bind ^[[D ed-prev-char")
     history = []
     while True:
         try:

--- a/agents/s05_skill_loading.py
+++ b/agents/s05_skill_loading.py
@@ -212,11 +212,10 @@ def agent_loop(messages: list):
 
 
 if __name__ == "__main__":
-    if readline and "libedit" in (readline.__doc__ or ""):
-        readline.parse_and_bind("bind ^[[A ed-prev-history")
-        readline.parse_and_bind("bind ^[[B ed-next-history")
-        readline.parse_and_bind("bind ^[[C em-next-char")
-        readline.parse_and_bind("bind ^[[D ed-prev-char")
+    readline.parse_and_bind("bind ^[[A ed-prev-history")
+    readline.parse_and_bind("bind ^[[B ed-next-history")
+    readline.parse_and_bind("bind ^[[C em-next-char")
+    readline.parse_and_bind("bind ^[[D ed-prev-char")
     history = []
     while True:
         try:

--- a/agents/s06_context_compact.py
+++ b/agents/s06_context_compact.py
@@ -234,11 +234,10 @@ def agent_loop(messages: list):
 
 
 if __name__ == "__main__":
-    if readline and "libedit" in (readline.__doc__ or ""):
-        readline.parse_and_bind("bind ^[[A ed-prev-history")
-        readline.parse_and_bind("bind ^[[B ed-next-history")
-        readline.parse_and_bind("bind ^[[C em-next-char")
-        readline.parse_and_bind("bind ^[[D ed-prev-char")
+    readline.parse_and_bind("bind ^[[A ed-prev-history")
+    readline.parse_and_bind("bind ^[[B ed-next-history")
+    readline.parse_and_bind("bind ^[[C em-next-char")
+    readline.parse_and_bind("bind ^[[D ed-prev-char")
     history = []
     while True:
         try:

--- a/agents/s07_task_system.py
+++ b/agents/s07_task_system.py
@@ -234,11 +234,10 @@ def agent_loop(messages: list):
 
 
 if __name__ == "__main__":
-    if readline and "libedit" in (readline.__doc__ or ""):
-        readline.parse_and_bind("bind ^[[A ed-prev-history")
-        readline.parse_and_bind("bind ^[[B ed-next-history")
-        readline.parse_and_bind("bind ^[[C em-next-char")
-        readline.parse_and_bind("bind ^[[D ed-prev-char")
+    readline.parse_and_bind("bind ^[[A ed-prev-history")
+    readline.parse_and_bind("bind ^[[B ed-next-history")
+    readline.parse_and_bind("bind ^[[C em-next-char")
+    readline.parse_and_bind("bind ^[[D ed-prev-char")
     history = []
     while True:
         try:

--- a/agents/s08_background_tasks.py
+++ b/agents/s08_background_tasks.py
@@ -220,11 +220,10 @@ def agent_loop(messages: list):
 
 
 if __name__ == "__main__":
-    if readline and "libedit" in (readline.__doc__ or ""):
-        readline.parse_and_bind("bind ^[[A ed-prev-history")
-        readline.parse_and_bind("bind ^[[B ed-next-history")
-        readline.parse_and_bind("bind ^[[C em-next-char")
-        readline.parse_and_bind("bind ^[[D ed-prev-char")
+    readline.parse_and_bind("bind ^[[A ed-prev-history")
+    readline.parse_and_bind("bind ^[[B ed-next-history")
+    readline.parse_and_bind("bind ^[[C em-next-char")
+    readline.parse_and_bind("bind ^[[D ed-prev-char")
     history = []
     while True:
         try:

--- a/agents/s09_agent_teams.py
+++ b/agents/s09_agent_teams.py
@@ -386,11 +386,10 @@ def agent_loop(messages: list):
 
 
 if __name__ == "__main__":
-    if readline and "libedit" in (readline.__doc__ or ""):
-        readline.parse_and_bind("bind ^[[A ed-prev-history")
-        readline.parse_and_bind("bind ^[[B ed-next-history")
-        readline.parse_and_bind("bind ^[[C em-next-char")
-        readline.parse_and_bind("bind ^[[D ed-prev-char")
+    readline.parse_and_bind("bind ^[[A ed-prev-history")
+    readline.parse_and_bind("bind ^[[B ed-next-history")
+    readline.parse_and_bind("bind ^[[C em-next-char")
+    readline.parse_and_bind("bind ^[[D ed-prev-char")
     history = []
     while True:
         try:

--- a/agents/s10_team_protocols.py
+++ b/agents/s10_team_protocols.py
@@ -467,11 +467,10 @@ def agent_loop(messages: list):
 
 
 if __name__ == "__main__":
-    if readline and "libedit" in (readline.__doc__ or ""):
-        readline.parse_and_bind("bind ^[[A ed-prev-history")
-        readline.parse_and_bind("bind ^[[B ed-next-history")
-        readline.parse_and_bind("bind ^[[C em-next-char")
-        readline.parse_and_bind("bind ^[[D ed-prev-char")
+    readline.parse_and_bind("bind ^[[A ed-prev-history")
+    readline.parse_and_bind("bind ^[[B ed-next-history")
+    readline.parse_and_bind("bind ^[[C em-next-char")
+    readline.parse_and_bind("bind ^[[D ed-prev-char")
     history = []
     while True:
         try:

--- a/agents/s11_autonomous_agents.py
+++ b/agents/s11_autonomous_agents.py
@@ -551,11 +551,10 @@ def agent_loop(messages: list):
 
 
 if __name__ == "__main__":
-    if readline and "libedit" in (readline.__doc__ or ""):
-        readline.parse_and_bind("bind ^[[A ed-prev-history")
-        readline.parse_and_bind("bind ^[[B ed-next-history")
-        readline.parse_and_bind("bind ^[[C em-next-char")
-        readline.parse_and_bind("bind ^[[D ed-prev-char")
+    readline.parse_and_bind("bind ^[[A ed-prev-history")
+    readline.parse_and_bind("bind ^[[B ed-next-history")
+    readline.parse_and_bind("bind ^[[C em-next-char")
+    readline.parse_and_bind("bind ^[[D ed-prev-char")
     history = []
     while True:
         try:

--- a/agents/s12_worktree_task_isolation.py
+++ b/agents/s12_worktree_task_isolation.py
@@ -763,11 +763,10 @@ def agent_loop(messages: list):
 
 
 if __name__ == "__main__":
-    if readline and "libedit" in (readline.__doc__ or ""):
-        readline.parse_and_bind("bind ^[[A ed-prev-history")
-        readline.parse_and_bind("bind ^[[B ed-next-history")
-        readline.parse_and_bind("bind ^[[C em-next-char")
-        readline.parse_and_bind("bind ^[[D ed-prev-char")
+    readline.parse_and_bind("bind ^[[A ed-prev-history")
+    readline.parse_and_bind("bind ^[[B ed-next-history")
+    readline.parse_and_bind("bind ^[[C em-next-char")
+    readline.parse_and_bind("bind ^[[D ed-prev-char")
     print(f"Repo root for s12: {REPO_ROOT}")
     if not WORKTREES.git_available:
         print("Note: Not in a git repo. worktree_* tools will return errors.")

--- a/agents/s_full.py
+++ b/agents/s_full.py
@@ -713,11 +713,10 @@ def agent_loop(messages: list):
 
 # === SECTION: repl ===
 if __name__ == "__main__":
-    if readline and "libedit" in (readline.__doc__ or ""):
-        readline.parse_and_bind("bind ^[[A ed-prev-history")
-        readline.parse_and_bind("bind ^[[B ed-next-history")
-        readline.parse_and_bind("bind ^[[C em-next-char")
-        readline.parse_and_bind("bind ^[[D ed-prev-char")
+    readline.parse_and_bind("bind ^[[A ed-prev-history")
+    readline.parse_and_bind("bind ^[[B ed-next-history")
+    readline.parse_and_bind("bind ^[[C em-next-char")
+    readline.parse_and_bind("bind ^[[D ed-prev-char")
     history = []
     while True:
         try:


### PR DESCRIPTION
Add 4 lines in each agent script's main block to bind arrow keys when the REPL runs under libedit, so ↑↓←→ move the cursor instead of inserting escape sequences like `^[[C`.

Changes
- Per file: optional `readline` import at top (try/except, `readline = None` on failure e.g. Windows), plus 4× `readline.parse_and_bind(...)` in main (up/down/left/right).
- Files: all agents with an interactive REPL: `s01_agent_loop.py` through `s12_worktree_task_isolation.py` and `s_full.py`.

现在的版本打错中文后删掉再发送就会触发UnicodeDecodeError，且不支持左右移动光标，每次打错字或者想补充都得重新启动程序，体验有点差。用最少代码包装了一下，体验好很多。
