### PR TITLE
Fix/agents repl readline unicode

### DIFF
--- a/agents/s01_agent_loop.py
+++ b/agents/s01_agent_loop.py
@@ -93,10 +93,6 @@ def agent_loop(messages: list):
 
 
 if __name__ == "__main__":
-    readline.parse_and_bind("bind ^[[A ed-prev-history")
-    readline.parse_and_bind("bind ^[[B ed-next-history")
-    readline.parse_and_bind("bind ^[[C em-next-char")
-    readline.parse_and_bind("bind ^[[D ed-prev-char")
     history = []
     while True:
         try:

--- a/agents/s02_tool_use.py
+++ b/agents/s02_tool_use.py
@@ -135,10 +135,6 @@ def agent_loop(messages: list):
 
 
 if __name__ == "__main__":
-    readline.parse_and_bind("bind ^[[A ed-prev-history")
-    readline.parse_and_bind("bind ^[[B ed-next-history")
-    readline.parse_and_bind("bind ^[[C em-next-char")
-    readline.parse_and_bind("bind ^[[D ed-prev-char")
     history = []
     while True:
         try:

--- a/agents/s03_todo_write.py
+++ b/agents/s03_todo_write.py
@@ -196,10 +196,6 @@ def agent_loop(messages: list):
 
 
 if __name__ == "__main__":
-    readline.parse_and_bind("bind ^[[A ed-prev-history")
-    readline.parse_and_bind("bind ^[[B ed-next-history")
-    readline.parse_and_bind("bind ^[[C em-next-char")
-    readline.parse_and_bind("bind ^[[D ed-prev-char")
     history = []
     while True:
         try:

--- a/agents/s04_subagent.py
+++ b/agents/s04_subagent.py
@@ -170,10 +170,6 @@ def agent_loop(messages: list):
 
 
 if __name__ == "__main__":
-    readline.parse_and_bind("bind ^[[A ed-prev-history")
-    readline.parse_and_bind("bind ^[[B ed-next-history")
-    readline.parse_and_bind("bind ^[[C em-next-char")
-    readline.parse_and_bind("bind ^[[D ed-prev-char")
     history = []
     while True:
         try:

--- a/agents/s05_skill_loading.py
+++ b/agents/s05_skill_loading.py
@@ -212,10 +212,6 @@ def agent_loop(messages: list):
 
 
 if __name__ == "__main__":
-    readline.parse_and_bind("bind ^[[A ed-prev-history")
-    readline.parse_and_bind("bind ^[[B ed-next-history")
-    readline.parse_and_bind("bind ^[[C em-next-char")
-    readline.parse_and_bind("bind ^[[D ed-prev-char")
     history = []
     while True:
         try:

--- a/agents/s06_context_compact.py
+++ b/agents/s06_context_compact.py
@@ -201,6 +201,7 @@ def agent_loop(messages: list):
         # Layer 1: micro_compact before each LLM call
         micro_compact(messages)
         # Layer 2: auto_compact if token estimate exceeds threshold
+        print(f"\033[33m$ Input tokens: {estimate_tokens(messages)}\033[0m")
         if estimate_tokens(messages) > THRESHOLD:
             print("[auto_compact triggered]")
             messages[:] = auto_compact(messages)
@@ -216,6 +217,7 @@ def agent_loop(messages: list):
         for block in response.content:
             if block.type == "tool_use":
                 if block.name == "compact":
+                    print(f"\033[33m$ Compact: {block.input['focus']}\033[0m")
                     manual_compact = True
                     output = "Compressing..."
                 else:
@@ -234,10 +236,6 @@ def agent_loop(messages: list):
 
 
 if __name__ == "__main__":
-    readline.parse_and_bind("bind ^[[A ed-prev-history")
-    readline.parse_and_bind("bind ^[[B ed-next-history")
-    readline.parse_and_bind("bind ^[[C em-next-char")
-    readline.parse_and_bind("bind ^[[D ed-prev-char")
     history = []
     while True:
         try:

--- a/agents/s07_task_system.py
+++ b/agents/s07_task_system.py
@@ -234,10 +234,6 @@ def agent_loop(messages: list):
 
 
 if __name__ == "__main__":
-    readline.parse_and_bind("bind ^[[A ed-prev-history")
-    readline.parse_and_bind("bind ^[[B ed-next-history")
-    readline.parse_and_bind("bind ^[[C em-next-char")
-    readline.parse_and_bind("bind ^[[D ed-prev-char")
     history = []
     while True:
         try:

--- a/agents/s08_background_tasks.py
+++ b/agents/s08_background_tasks.py
@@ -220,10 +220,6 @@ def agent_loop(messages: list):
 
 
 if __name__ == "__main__":
-    readline.parse_and_bind("bind ^[[A ed-prev-history")
-    readline.parse_and_bind("bind ^[[B ed-next-history")
-    readline.parse_and_bind("bind ^[[C em-next-char")
-    readline.parse_and_bind("bind ^[[D ed-prev-char")
     history = []
     while True:
         try:

--- a/agents/s09_agent_teams.py
+++ b/agents/s09_agent_teams.py
@@ -386,10 +386,6 @@ def agent_loop(messages: list):
 
 
 if __name__ == "__main__":
-    readline.parse_and_bind("bind ^[[A ed-prev-history")
-    readline.parse_and_bind("bind ^[[B ed-next-history")
-    readline.parse_and_bind("bind ^[[C em-next-char")
-    readline.parse_and_bind("bind ^[[D ed-prev-char")
     history = []
     while True:
         try:

--- a/agents/s10_team_protocols.py
+++ b/agents/s10_team_protocols.py
@@ -467,10 +467,6 @@ def agent_loop(messages: list):
 
 
 if __name__ == "__main__":
-    readline.parse_and_bind("bind ^[[A ed-prev-history")
-    readline.parse_and_bind("bind ^[[B ed-next-history")
-    readline.parse_and_bind("bind ^[[C em-next-char")
-    readline.parse_and_bind("bind ^[[D ed-prev-char")
     history = []
     while True:
         try:

--- a/agents/s11_autonomous_agents.py
+++ b/agents/s11_autonomous_agents.py
@@ -551,10 +551,6 @@ def agent_loop(messages: list):
 
 
 if __name__ == "__main__":
-    readline.parse_and_bind("bind ^[[A ed-prev-history")
-    readline.parse_and_bind("bind ^[[B ed-next-history")
-    readline.parse_and_bind("bind ^[[C em-next-char")
-    readline.parse_and_bind("bind ^[[D ed-prev-char")
     history = []
     while True:
         try:

--- a/agents/s12_worktree_task_isolation.py
+++ b/agents/s12_worktree_task_isolation.py
@@ -763,10 +763,6 @@ def agent_loop(messages: list):
 
 
 if __name__ == "__main__":
-    readline.parse_and_bind("bind ^[[A ed-prev-history")
-    readline.parse_and_bind("bind ^[[B ed-next-history")
-    readline.parse_and_bind("bind ^[[C em-next-char")
-    readline.parse_and_bind("bind ^[[D ed-prev-char")
     print(f"Repo root for s12: {REPO_ROOT}")
     if not WORKTREES.git_available:
         print("Note: Not in a git repo. worktree_* tools will return errors.")

--- a/agents/s_full.py
+++ b/agents/s_full.py
@@ -713,10 +713,6 @@ def agent_loop(messages: list):
 
 # === SECTION: repl ===
 if __name__ == "__main__":
-    readline.parse_and_bind("bind ^[[A ed-prev-history")
-    readline.parse_and_bind("bind ^[[B ed-next-history")
-    readline.parse_and_bind("bind ^[[C em-next-char")
-    readline.parse_and_bind("bind ^[[D ed-prev-char")
     history = []
     while True:
         try:


### PR DESCRIPTION
Changes
Per file: optional readline import at top (try/except, readline = None on failure e.g. Windows).
Files: all agents with an interactive REPL: s01_agent_loop.py through s12_worktree_task_isolation.py and s_full.py.

现在的版本打错中文后删掉再发送就会触发UnicodeDecodeError，且不支持左右移动光标，每次打错字或者想补充都得重新启动程序，体验有点差。用readline包装了一下，体验好很多，且不会影响Windows系统。

另外在s06加入了两行print代码以便用户更好地理解compact的过程：一行打印当前token数，一行打印了手动compact前模型的“focus”，把这个TOOLS中的参数利用了起来，以便用户更好理解模型的思路。