### PR TITLE
fix(task-system): sync blocks when adding blockedBy dependencies

### DIFF
--- a/agents/s07_task_system.py
+++ b/agents/s07_task_system.py
@@ -87,6 +87,15 @@ class TaskManager:
                 self._clear_dependency(task_id)
         if add_blocked_by:
             task["blockedBy"] = list(set(task["blockedBy"] + add_blocked_by))
+            # Bidirectional: also update the blocker tasks' blocks lists
+            for blocker_id in add_blocked_by:
+                try:
+                    blocker = self._load(blocker_id)
+                    if task_id not in blocker["blocks"]:
+                        blocker["blocks"].append(task_id)
+                        self._save(blocker)
+                except ValueError:
+                    pass
         if add_blocks:
             task["blocks"] = list(set(task["blocks"] + add_blocks))
             # Bidirectional: also update the blocked tasks' blockedBy lists


### PR DESCRIPTION
## Summary

  This fixes an inconsistency in `TaskManager.update()` dependency synchronization.

  Previously:
  - `addBlocks` updated both sides of the relationship
  - `addBlockedBy` only updated the current task's `blockedBy`

  This could leave `blocks` and `blockedBy` out of sync.

  ## Change

  When calling `TASKS.update(task_id, add_blocked_by=[...])`, the task manager now also updates each blocker task's `blocks` list, making dependency
  synchronization bidirectional.

  ## Example

  Before:
  - `TASKS.update(3, add_blocked_by=[2])`
  - Task 3 would get `blockedBy: [2]`
  - Task 2 would not get `blocks: [3]`

  After:
  - Task 3 gets `blockedBy: [2]`
  - Task 2 also gets `blocks: [3]`

  ## Validation

  Verified with a minimal task setup that calling:

  ```python
  TASKS.update(3, add_blocked_by=[2])

  updates both:

  - task 3 blockedBy
  - task 2 blocks