### PR TITLE
Fix typos in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,8 +225,8 @@ learn-claude-code                   claw0
 ## About
 <img width="260" src="https://github.com/user-attachments/assets/fe8b852b-97da-4061-a467-9694906b5edf" /><br>
 
-Scan with Wechat to fellow us,  
-or fellow on X: [shareAI-Lab](https://x.com/baicai003)  
+Scan with WeChat to follow us,
+or follow on X: [shareAI-Lab](https://x.com/baicai003)  
 
 ## License
 


### PR DESCRIPTION
## Summary

Great project — really enjoyed going through the progressive sessions! Just noticed a couple of small typos in the About section of the README:

- "fellow" → "follow" (two occurrences)
- "Wechat" → "WeChat" (brand capitalization)

## Changes

Single-line fix in `README.md`, no functional changes.