### PR TITLE
fix: use yaml.safe_load to parse SKILL.md frontmatter

### DIFF
--- a/agents/s05_skill_loading.py
+++ b/agents/s05_skill_loading.py
@@ -40,6 +40,8 @@ import re
 import subprocess
 from pathlib import Path
 
+import yaml
+
 from anthropic import Anthropic
 from dotenv import load_dotenv
 
@@ -75,11 +77,7 @@ class SkillLoader:
         match = re.match(r"^---\n(.*?)\n---\n(.*)", text, re.DOTALL)
         if not match:
             return {}, text
-        meta = {}
-        for line in match.group(1).strip().splitlines():
-            if ":" in line:
-                key, val = line.split(":", 1)
-                meta[key.strip()] = val.strip()
+        meta = yaml.safe_load(match.group(1)) or {}
         return meta, match.group(2).strip()
 
     def get_descriptions(self) -> str:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 anthropic>=0.25.0
 python-dotenv>=1.0.0
+pyyaml>=6.0


### PR DESCRIPTION
_parse_frontmatter 使用逐行 : 分割解析 YAML，无法正确处理 | / > 块标量语法（如 agent-builder/SKILL.md 的多行 description）。

改用 yaml.safe_load() 替代手写解析，正确支持所有 YAML 语法。

Changes:
agents/s05_skill_loading.py: 替换 _parse_frontmatter 实现
requirements.txt: 添加 pyyaml>=6.0 依赖