### PR TITLE
feat: upgrade MiniMax default model to M2.7

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,7 +14,9 @@ MODEL_ID=claude-sonnet-4-6
 #  Provider         MODEL_ID              SWE-bench  TB2     Base URL
 #  ---------------  --------------------  ---------  ------  -------------------
 #  Anthropic        claude-sonnet-4-6     79.6%      59.1%   (default)
-#  MiniMax          MiniMax-M2.5          80.2%        -     see below
+#  MiniMax          MiniMax-M2.7            -          -     see below
+#                   MiniMax-M2.7-highspeed  -          -     see below
+#                   MiniMax-M2.5          80.2%        -     see below
 #  GLM (Zhipu)      glm-5                77.8%        -     see below
 #  Kimi (Moonshot)  kimi-k2.5            76.8%        -     see below
 #  DeepSeek         deepseek-chat        73.0%        -     see below
@@ -28,7 +30,9 @@ MODEL_ID=claude-sonnet-4-6
 
 # MiniMax          https://www.minimax.io
 # ANTHROPIC_BASE_URL=https://api.minimax.io/anthropic
-# MODEL_ID=MiniMax-M2.5
+# MODEL_ID=MiniMax-M2.7
+# MODEL_ID=MiniMax-M2.7-highspeed  # (high-speed, low-latency alternative)
+# MODEL_ID=MiniMax-M2.5            # (previous generation)
 
 # GLM (Zhipu)      https://z.ai
 # ANTHROPIC_BASE_URL=https://api.z.ai/api/anthropic
@@ -46,7 +50,9 @@ MODEL_ID=claude-sonnet-4-6
 
 # MiniMax          https://platform.minimax.io
 # ANTHROPIC_BASE_URL=https://api.minimaxi.com/anthropic
-# MODEL_ID=MiniMax-M2.5
+# MODEL_ID=MiniMax-M2.7
+# MODEL_ID=MiniMax-M2.7-highspeed  # (high-speed, low-latency alternative)
+# MODEL_ID=MiniMax-M2.5            # (previous generation)
 
 # GLM (Zhipu)      https://open.bigmodel.cn
 # ANTHROPIC_BASE_URL=https://open.bigmodel.cn/api/anthropic


### PR DESCRIPTION
## Summary
- Add MiniMax-M2.7 and MiniMax-M2.7-highspeed to the model selection list
- Set MiniMax-M2.7 as the new default model for both international and China mainland endpoints
- Retain MiniMax-M2.5 as a previous generation alternative

## Changes
Updated `.env.example` to include the latest MiniMax M2.7 models:
- **MiniMax-M2.7** — Latest flagship model with enhanced reasoning and coding capabilities (new default)
- **MiniMax-M2.7-highspeed** — High-speed version of M2.7 for low-latency scenarios
- **MiniMax-M2.5** — Kept as previous generation option

## Why
MiniMax-M2.7 is the latest flagship model with enhanced reasoning and coding capabilities, superseding M2.5 as the recommended default.

## Testing
- Verified all MODEL_ID references updated correctly
- Both international (api.minimax.io) and China mainland (api.minimaxi.com) sections updated consistently
