### PR TITLE
fix: fix auto_compact truncating latest conversation content

### DIFF
--- a/agents/s06_context_compact.py
+++ b/agents/s06_context_compact.py
@@ -104,7 +104,7 @@ def auto_compact(messages: list) -> list:
             f.write(json.dumps(msg, default=str) + "\n")
     print(f"[transcript saved: {transcript_path}]")
     # Ask LLM to summarize
-    conversation_text = json.dumps(messages, default=str)[:80000]
+    conversation_text = json.dumps(messages, default=str)[-80000:]
     response = client.messages.create(
         model=MODEL,
         messages=[{"role": "user", "content":


### PR DESCRIPTION
### Related Issue
Closes #109

### Problem Description
In the `auto_compact` function of `s06_context_compact.py`, the code uses `[:80000]` to intercept the beginning of the string.
Since the `messages` list is stored in chronological order (oldest first, newest last), this causes the latest tool execution results and task status to be discarded directly.
The generated summary loses current progress, making the agent "amnesiac" after compression.

### Fix
Changed string interception from start to end:
```python
# Before
conversation_text = json.dumps(messages, default=str)[:80000]
# After
conversation_text = json.dumps(messages, default=str)[-80000:]