### PR TITLE
fix: place reminder text after tool_result in message content

### DIFF
--- a/agents/s03_todo_write.py
+++ b/agents/s03_todo_write.py
@@ -187,7 +187,7 @@ def agent_loop(messages: list):
                     used_todo = True
         rounds_since_todo = 0 if used_todo else rounds_since_todo + 1
         if rounds_since_todo >= 3:
-            results.insert(0, {"type": "text", "text": "<reminder>Update your todos.</reminder>"})
+            results.append({"type": "text", "text": "<reminder>Update your todos.</reminder>"})
         messages.append({"role": "user", "content": results})
 
 


### PR DESCRIPTION
## Summary
- Fix bug where reminder text was inserted before tool_result blocks
- Changed insert(0, ...) to append(...) to comply with Anthropic API requirement

## Test plan
- Run agents/s03_todo_write.py and let it run 3+ rounds without todo update
- Verify no API error occurs