### PR TITLE
feat(agents): use PyYAML for SKILL.md frontmatter parsing

### DIFF
--- a/agents/s05_skill_loading.py
+++ b/agents/s05_skill_loading.py
@@ -39,7 +39,7 @@ import os
 import re
 import subprocess
 from pathlib import Path
-
+import yaml
 from anthropic import Anthropic
 from dotenv import load_dotenv
 
@@ -71,16 +71,15 @@ class SkillLoader:
             self.skills[name] = {"meta": meta, "body": body, "path": str(f)}
 
     def _parse_frontmatter(self, text: str) -> tuple:
-        """Parse YAML frontmatter between --- delimiters."""
         match = re.match(r"^---\n(.*?)\n---\n(.*)", text, re.DOTALL)
         if not match:
             return {}, text
-        meta = {}
-        for line in match.group(1).strip().splitlines():
-            if ":" in line:
-                key, val = line.split(":", 1)
-                meta[key.strip()] = val.strip()
-        return meta, match.group(2).strip()
+        try:
+            meta = yaml.safe_load(match.group(1))
+        except yaml.YAMLError:
+            meta = {}
+        return meta or {}, match.group(2).strip()
+
 
     def get_descriptions(self) -> str:
         """Layer 1: short descriptions for the system prompt."""

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 anthropic>=0.25.0
 python-dotenv>=1.0.0
+pyyaml>=6.0


### PR DESCRIPTION
- Replace manual line-by-line parsing with yaml.safe_load()
- Add proper YAML error handling with try/except
- Add pyyaml>=6.0 to requirements.txt

This improves robustness when parsing SKILL.md frontmatter with complex YAML structures (nested objects, lists, multi-line strings).