### PR TITLE
fix: keep non-ASCII text readable in task JSON files

### DIFF
--- a/agents/s07_task_system.py
+++ b/agents/s07_task_system.py
@@ -62,7 +62,7 @@ class TaskManager:
 
     def _save(self, task: dict):
         path = self.dir / f"task_{task['id']}.json"
-        path.write_text(json.dumps(task, indent=2))
+        path.write_text(json.dumps(task, indent=2, ensure_ascii=False))
 
     def create(self, subject: str, description: str = "") -> str:
         task = {
@@ -71,10 +71,10 @@ class TaskManager:
         }
         self._save(task)
         self._next_id += 1
-        return json.dumps(task, indent=2)
+        return json.dumps(task, indent=2, ensure_ascii=False)
 
     def get(self, task_id: int) -> str:
-        return json.dumps(self._load(task_id), indent=2)
+        return json.dumps(self._load(task_id), indent=2, ensure_ascii=False)
 
     def update(self, task_id: int, status: str = None,
                add_blocked_by: list = None, add_blocks: list = None) -> str:
@@ -100,7 +100,7 @@ class TaskManager:
                 except ValueError:
                     pass
         self._save(task)
-        return json.dumps(task, indent=2)
+        return json.dumps(task, indent=2, ensure_ascii=False)
 
     def _clear_dependency(self, completed_id: int):
         """Remove completed_id from all other tasks' blockedBy lists."""


### PR DESCRIPTION
## Problem

Task files in `.tasks/task_*.json` save Chinese and other non-ASCII characters as escaped Unicode sequences like `\u6c47\u603b\u6210\u6700\u7ec8\u62a5\u544a` instead of the actual readable text `汇总成最终报告`.

This makes it very hard to debug task files when you open them in editor or terminal. You cannot read what the task is about without running it through a decoder first.

## Fix

Added `ensure_ascii=False` parameter to all 4 `json.dumps()` calls in `s07_task_system.py`:

1. `_save()` method (line 65) - writes task to disk
2. `create()` return value (line 74) - returns new task as JSON string
3. `get()` return value (line 77) - returns loaded task as JSON string
4. `update()` return value (line 103) - returns updated task as JSON string

Before:
```json
{"subject": "\u6c47\u603b\u6210\u6700\u7ec8\u62a5\u544a"}
```

After:
```json
{"subject": "汇总成最终报告"}
```

Both formats are valid JSON and `json.loads()` handles them identical, so this change is fully backward compatible with existing task files. The only difference is readability.

## Verification

- Python syntax check passes
- No behavioral change, just formatting of the output

Closes #106