### PR TITLE
Fix:  s_full.py print text responses in __main__ REPL loop

### DIFF
--- a/agents/s_full.py
+++ b/agents/s_full.py
@@ -733,4 +733,9 @@ if __name__ == "__main__":
             continue
         history.append({"role": "user", "content": query})
         agent_loop(history)
+        response_content = history[-1]["content"]
+        if isinstance(response_content, list):
+            for block in response_content:
+                if hasattr(block, "text"):
+                    print(block.text)
         print()


### PR DESCRIPTION
When running s_full.py directly, the LLM's text responses are not printed to the terminal. Users cannot see the assistant's replies in the REPL, making the interactive loop unusable.
