### PR TITLE
fix: skill description not fully loaded from SKILL.md frontmatter

### DIFF
--- a/agents/s05_skill_loading.py
+++ b/agents/s05_skill_loading.py
@@ -38,6 +38,7 @@ Key insight: "Don't put everything in the system prompt. Load on demand."
 import os
 import re
 import subprocess
+import yaml
 from pathlib import Path
 
 from anthropic import Anthropic
@@ -75,11 +76,10 @@ class SkillLoader:
         match = re.match(r"^---\n(.*?)\n---\n(.*)", text, re.DOTALL)
         if not match:
             return {}, text
-        meta = {}
-        for line in match.group(1).strip().splitlines():
-            if ":" in line:
-                key, val = line.split(":", 1)
-                meta[key.strip()] = val.strip()
+        try:
+            meta = yaml.safe_load(match.group(1)) or {}
+        except yaml.YAMLError:
+            meta = {}
         return meta, match.group(2).strip()
 
     def get_descriptions(self) -> str:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 anthropic>=0.25.0
 python-dotenv>=1.0.0
+pyyaml>=6.0


### PR DESCRIPTION
## Problem
`_parse_frontmatter` splits lines manually and only reads `key: value` pairs.
When a skill's `SKILL.md` uses YAML block scalars (`|`), the description
is parsed as `"|"` — all indented continuation lines are silently dropped.

## Root Cause
```python
# Before: only handles simple key: value
for line in match.group(1).strip().splitlines():
    if ":" in line:
        key, val = line.split(":", 1)
```

## Fix
Replace manual parsing with `yaml.safe_load()`, which correctly handles
all standard YAML syntax including multi-line block scalars.

## Test
Skills with `description: |` now load their full description correctly.
For example, `agent-builder`'s full description is now visible in the system prompt
instead of a single `|` character.