### PR TITLE
fix: append nag reminder instead of inserting at front

### DIFF
--- a/agents/s03_todo_write.py
+++ b/agents/s03_todo_write.py
@@ -187,7 +187,7 @@ def agent_loop(messages: list):
                     used_todo = True
         rounds_since_todo = 0 if used_todo else rounds_since_todo + 1
         if rounds_since_todo >= 3:
-            results.insert(0, {"type": "text", "text": "<reminder>Update your todos.</reminder>"})
+            results.append({"type": "text", "text": "<reminder>Update your todos.</reminder>"})
         messages.append({"role": "user", "content": results})
 
 


### PR DESCRIPTION
## Root cause

The Anthropic Messages API requires that when an assistant message contains \`tool_use\` blocks, the immediately following user message must have \`tool_result\` blocks **before** any other content. Using \`results.insert(0, ...)\` placed a \`text\` block at index 0 — ahead of all \`tool_result\` blocks — causing the API to treat the preceding \`tool_use\` blocks as unmatched.

This triggered a \`400 BadRequestError\` on the 4th agent loop iteration (when \`rounds_since_todo >= 3\` first fires):

```
anthropic.BadRequestError: Error code: 400 - {
  'type': 'error',
  'error': {
    'type': 'invalid_request_error',
    'message': \"messages.6: tool_use ids were found without tool_result blocks immediately after.
      Each tool_use block must have a corresponding tool_result block in the next message.\"
  }
}
```

## Fix

Change `insert(0, ...)` to `append(...)` so the reminder `text` block trails after all `tool_result` blocks. The API accepts mixed `text` + `tool_result` content in a user message as long as `tool_result` blocks come first.

## Test plan
- [ ] Run `s03_todo_write.py` with \`Refactor the file hello.py: add type hints, docstrings, and a main guard\`
- [ ] Confirm the nag fires at round 3 without a `BadRequestError`

🤖 Generated with [Claude Code](https://claude.com/claude-code)