### PR TITLE
test: replace stale Python checks with smoke tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ on:
     branches: [main]
 
 jobs:
-  unit-test:
+  python-smoke:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -18,33 +18,10 @@ jobs:
           python-version: "3.11"
 
       - name: Install dependencies
-        run: pip install anthropic python-dotenv
+        run: pip install anthropic python-dotenv pytest
 
-      - name: Run unit tests
-        run: python tests/test_unit.py
-
-  session-test:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        session: [v0, v1, v2, v3, v4, v5, v6, v7, v8a, v8b, v8c, v9]
-    steps:
-      - uses: actions/checkout@v6
-
-      - name: Set up Python
-        uses: actions/setup-python@v6
-        with:
-          python-version: "3.11"
-
-      - name: Install dependencies
-        run: pip install anthropic python-dotenv
-
-      - name: Run ${{ matrix.session }} tests
-        env:
-          TEST_API_KEY: ${{ secrets.TEST_API_KEY }}
-          TEST_BASE_URL: ${{ secrets.TEST_BASE_URL }}
-          TEST_MODEL: ${{ secrets.TEST_MODEL }}
-        run: python tests/test_${{ matrix.session }}.py
+      - name: Run Python smoke tests
+        run: python -m pytest tests/test_agents_smoke.py -q
 
   web-build:
     runs-on: ubuntu-latest

--- a/tests/test_agents_smoke.py
+++ b/tests/test_agents_smoke.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from pathlib import Path
+import py_compile
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+AGENTS_DIR = ROOT / "agents"
+AGENT_FILES = sorted(
+    path for path in AGENTS_DIR.glob("*.py") if path.name != "__init__.py"
+)
+AGENT_IDS = [path.name for path in AGENT_FILES]
+
+
+@pytest.mark.parametrize("agent_path", AGENT_FILES, ids=AGENT_IDS)
+def test_agent_scripts_compile(agent_path: Path) -> None:
+    _ = py_compile.compile(str(agent_path), doraise=True)
+
+
+def test_agent_scripts_exist() -> None:
+    assert AGENT_FILES, "expected at least one agent script"


### PR DESCRIPTION
## Summary
- replace the stale Python workflow steps that referenced missing test files with the repository's actual smoke suite
- add `tests/test_agents_smoke.py` so CI verifies every agent script still compiles

## Testing
- `python -m pytest tests/test_agents_smoke.py -q`