### PR TITLE
fix: pin GitHub Actions to immutable commit SHAs (#146)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,9 +14,9 @@ jobs:
         working-directory: web
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f
         with:
           node-version: 20
           cache: npm

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,10 +10,10 @@ jobs:
   python-smoke:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
         with:
           python-version: "3.11"
 
@@ -29,10 +29,10 @@ jobs:
       run:
         working-directory: web
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Set up Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f
         with:
           node-version: "20"
           cache: "npm"


### PR DESCRIPTION
## Summary

Replace mutable GitHub Actions version tags (e.g. `actions/checkout@v6`) with immutable full-length commit SHAs to reduce CI/CD supply-chain risk.

## Changes

Pinned actions in `.github/workflows/ci.yml` and `.github/workflows/test.yml`:

| Action | Old | New SHA |
|--------|-----|---------|
| actions/checkout | @v6 | @de0fac2e4500dabe0009e67214ff5f5447ce83dd |
| actions/setup-node | @v6 | @53b83947a5a98c8d113130e565377fae1a50d02f |
| actions/setup-python | @v6 | @a309ff8b426b58ec0e2a45f0f869d46889d02405 |

Refs: #146