### PR TITLE
fix: pin GitHub Actions to immutable commit SHAs (#146)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,9 +14,9 @@ jobs:
         working-directory: web
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f
         with:
           node-version: 20
           cache: npm

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,10 +10,10 @@ jobs:
   python-smoke:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
         with:
           python-version: "3.11"
 
@@ -29,10 +29,10 @@ jobs:
       run:
         working-directory: web
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Set up Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f
         with:
           node-version: "20"
           cache: "npm"


### PR DESCRIPTION
## Fix Issue #146: Pin GitHub Actions to immutable commit SHAs

Pin GitHub Actions workflow refs to their immutable commit SHAs instead of using floating tags like `actions/checkout@v6`. This prevents supply chain attacks where a tag could be moved to point to a malicious commit.

**Changes (2 files, +6/-6 lines):**
- `.github/workflows/ci.yml`: pin `actions/checkout` and `actions/setup-node` to SHA
- `.github/workflows/test.yml`: pin `actions/checkout`, `actions/setup-python`, and `actions/setup-node` to SHA

**Note on Vercel status checks:** The Vercel deployment checks are failing with "Authorization required" — this is a pre-existing Vercel account authorization issue unrelated to this PR's code changes.

Reference: https://docs.github.com/en/actions/security-for-github-actions/security-guidelines/blocking-a-pull-request-from-using-fork-action-versions