### PR TITLE
Fix client authentication: properly support both Anthropic API and third-party endpoints

### DIFF
--- a/agents/s01_agent_loop.py
+++ b/agents/s01_agent_loop.py
@@ -43,10 +43,12 @@ from dotenv import load_dotenv
 
 load_dotenv(override=True)
 
-if os.getenv("ANTHROPIC_BASE_URL"):
-    os.environ.pop("ANTHROPIC_AUTH_TOKEN", None)
+# using either ANTHROPIC_BASE_URL + ANTHROPIC_AUTH_TOKEN or ANTHROPIC_API_KEY is supported
+if os.getenv("ANTHROPIC_BASE_URL") and os.getenv("ANTHROPIC_AUTH_TOKEN") and not os.getenv("ANTHROPIC_API_KEY"):
+    client = Anthropic(base_url=os.getenv("ANTHROPIC_BASE_URL"), auth_token=os.getenv("ANTHROPIC_AUTH_TOKEN"))
+elif os.getenv("ANTHROPIC_API_KEY") and not os.getenv("ANTHROPIC_BASE_URL") and not os.getenv("ANTHROPIC_AUTH_TOKEN"):
+    client = Anthropic(api_key=os.getenv("ANTHROPIC_API_KEY"))
 
-client = Anthropic(base_url=os.getenv("ANTHROPIC_BASE_URL"))
 MODEL = os.environ["MODEL_ID"]
 
 SYSTEM = f"You are a coding agent at {os.getcwd()}. Use bash to solve tasks. Act, don't explain."

--- a/agents/s02_tool_use.py
+++ b/agents/s02_tool_use.py
@@ -28,11 +28,13 @@ from dotenv import load_dotenv
 
 load_dotenv(override=True)
 
-if os.getenv("ANTHROPIC_BASE_URL"):
-    os.environ.pop("ANTHROPIC_AUTH_TOKEN", None)
+# using either ANTHROPIC_BASE_URL + ANTHROPIC_AUTH_TOKEN or ANTHROPIC_API_KEY is supported
+if os.getenv("ANTHROPIC_BASE_URL") and os.getenv("ANTHROPIC_AUTH_TOKEN") and not os.getenv("ANTHROPIC_API_KEY"):
+    client = Anthropic(base_url=os.getenv("ANTHROPIC_BASE_URL"), auth_token=os.getenv("ANTHROPIC_AUTH_TOKEN"))
+elif os.getenv("ANTHROPIC_API_KEY") and not os.getenv("ANTHROPIC_BASE_URL") and not os.getenv("ANTHROPIC_AUTH_TOKEN"):
+    client = Anthropic(api_key=os.getenv("ANTHROPIC_API_KEY"))
 
 WORKDIR = Path.cwd()
-client = Anthropic(base_url=os.getenv("ANTHROPIC_BASE_URL"))
 MODEL = os.environ["MODEL_ID"]
 
 SYSTEM = f"You are a coding agent at {WORKDIR}. Use tools to solve tasks. Act, don't explain."

--- a/agents/s03_todo_write.py
+++ b/agents/s03_todo_write.py
@@ -36,11 +36,13 @@ from dotenv import load_dotenv
 
 load_dotenv(override=True)
 
-if os.getenv("ANTHROPIC_BASE_URL"):
-    os.environ.pop("ANTHROPIC_AUTH_TOKEN", None)
+# using either ANTHROPIC_BASE_URL + ANTHROPIC_AUTH_TOKEN or ANTHROPIC_API_KEY is supported
+if os.getenv("ANTHROPIC_BASE_URL") and os.getenv("ANTHROPIC_AUTH_TOKEN") and not os.getenv("ANTHROPIC_API_KEY"):
+    client = Anthropic(base_url=os.getenv("ANTHROPIC_BASE_URL"), auth_token=os.getenv("ANTHROPIC_AUTH_TOKEN"))
+elif os.getenv("ANTHROPIC_API_KEY") and not os.getenv("ANTHROPIC_BASE_URL") and not os.getenv("ANTHROPIC_AUTH_TOKEN"):
+    client = Anthropic(api_key=os.getenv("ANTHROPIC_API_KEY"))
 
 WORKDIR = Path.cwd()
-client = Anthropic(base_url=os.getenv("ANTHROPIC_BASE_URL"))
 MODEL = os.environ["MODEL_ID"]
 
 SYSTEM = f"""You are a coding agent at {WORKDIR}.

--- a/agents/s04_subagent.py
+++ b/agents/s04_subagent.py
@@ -32,11 +32,13 @@ from dotenv import load_dotenv
 
 load_dotenv(override=True)
 
-if os.getenv("ANTHROPIC_BASE_URL"):
-    os.environ.pop("ANTHROPIC_AUTH_TOKEN", None)
+# using either ANTHROPIC_BASE_URL + ANTHROPIC_AUTH_TOKEN or ANTHROPIC_API_KEY is supported
+if os.getenv("ANTHROPIC_BASE_URL") and os.getenv("ANTHROPIC_AUTH_TOKEN") and not os.getenv("ANTHROPIC_API_KEY"):
+    client = Anthropic(base_url=os.getenv("ANTHROPIC_BASE_URL"), auth_token=os.getenv("ANTHROPIC_AUTH_TOKEN"))
+elif os.getenv("ANTHROPIC_API_KEY") and not os.getenv("ANTHROPIC_BASE_URL") and not os.getenv("ANTHROPIC_AUTH_TOKEN"):
+    client = Anthropic(api_key=os.getenv("ANTHROPIC_API_KEY"))
 
 WORKDIR = Path.cwd()
-client = Anthropic(base_url=os.getenv("ANTHROPIC_BASE_URL"))
 MODEL = os.environ["MODEL_ID"]
 
 SYSTEM = f"You are a coding agent at {WORKDIR}. Use the task tool to delegate exploration or subtasks."

--- a/agents/s05_skill_loading.py
+++ b/agents/s05_skill_loading.py
@@ -46,11 +46,13 @@ from dotenv import load_dotenv
 
 load_dotenv(override=True)
 
-if os.getenv("ANTHROPIC_BASE_URL"):
-    os.environ.pop("ANTHROPIC_AUTH_TOKEN", None)
+# using either ANTHROPIC_BASE_URL + ANTHROPIC_AUTH_TOKEN or ANTHROPIC_API_KEY is supported
+if os.getenv("ANTHROPIC_BASE_URL") and os.getenv("ANTHROPIC_AUTH_TOKEN") and not os.getenv("ANTHROPIC_API_KEY"):
+    client = Anthropic(base_url=os.getenv("ANTHROPIC_BASE_URL"), auth_token=os.getenv("ANTHROPIC_AUTH_TOKEN"))
+elif os.getenv("ANTHROPIC_API_KEY") and not os.getenv("ANTHROPIC_BASE_URL") and not os.getenv("ANTHROPIC_AUTH_TOKEN"):
+    client = Anthropic(api_key=os.getenv("ANTHROPIC_API_KEY"))
 
 WORKDIR = Path.cwd()
-client = Anthropic(base_url=os.getenv("ANTHROPIC_BASE_URL"))
 MODEL = os.environ["MODEL_ID"]
 SKILLS_DIR = WORKDIR / "skills"
 

--- a/agents/s06_context_compact.py
+++ b/agents/s06_context_compact.py
@@ -45,11 +45,13 @@ from dotenv import load_dotenv
 
 load_dotenv(override=True)
 
-if os.getenv("ANTHROPIC_BASE_URL"):
-    os.environ.pop("ANTHROPIC_AUTH_TOKEN", None)
+# using either ANTHROPIC_BASE_URL + ANTHROPIC_AUTH_TOKEN or ANTHROPIC_API_KEY is supported
+if os.getenv("ANTHROPIC_BASE_URL") and os.getenv("ANTHROPIC_AUTH_TOKEN") and not os.getenv("ANTHROPIC_API_KEY"):
+    client = Anthropic(base_url=os.getenv("ANTHROPIC_BASE_URL"), auth_token=os.getenv("ANTHROPIC_AUTH_TOKEN"))
+elif os.getenv("ANTHROPIC_API_KEY") and not os.getenv("ANTHROPIC_BASE_URL") and not os.getenv("ANTHROPIC_AUTH_TOKEN"):
+    client = Anthropic(api_key=os.getenv("ANTHROPIC_API_KEY"))
 
 WORKDIR = Path.cwd()
-client = Anthropic(base_url=os.getenv("ANTHROPIC_BASE_URL"))
 MODEL = os.environ["MODEL_ID"]
 
 SYSTEM = f"You are a coding agent at {WORKDIR}. Use tools to solve tasks."

--- a/agents/s07_task_system.py
+++ b/agents/s07_task_system.py
@@ -32,11 +32,13 @@ from dotenv import load_dotenv
 
 load_dotenv(override=True)
 
-if os.getenv("ANTHROPIC_BASE_URL"):
-    os.environ.pop("ANTHROPIC_AUTH_TOKEN", None)
+# using either ANTHROPIC_BASE_URL + ANTHROPIC_AUTH_TOKEN or ANTHROPIC_API_KEY is supported
+if os.getenv("ANTHROPIC_BASE_URL") and os.getenv("ANTHROPIC_AUTH_TOKEN") and not os.getenv("ANTHROPIC_API_KEY"):
+    client = Anthropic(base_url=os.getenv("ANTHROPIC_BASE_URL"), auth_token=os.getenv("ANTHROPIC_AUTH_TOKEN"))
+elif os.getenv("ANTHROPIC_API_KEY") and not os.getenv("ANTHROPIC_BASE_URL") and not os.getenv("ANTHROPIC_AUTH_TOKEN"):
+    client = Anthropic(api_key=os.getenv("ANTHROPIC_API_KEY"))
 
 WORKDIR = Path.cwd()
-client = Anthropic(base_url=os.getenv("ANTHROPIC_BASE_URL"))
 MODEL = os.environ["MODEL_ID"]
 TASKS_DIR = WORKDIR / ".tasks"
 

--- a/agents/s08_background_tasks.py
+++ b/agents/s08_background_tasks.py
@@ -36,11 +36,13 @@ from dotenv import load_dotenv
 
 load_dotenv(override=True)
 
-if os.getenv("ANTHROPIC_BASE_URL"):
-    os.environ.pop("ANTHROPIC_AUTH_TOKEN", None)
+# using either ANTHROPIC_BASE_URL + ANTHROPIC_AUTH_TOKEN or ANTHROPIC_API_KEY is supported
+if os.getenv("ANTHROPIC_BASE_URL") and os.getenv("ANTHROPIC_AUTH_TOKEN") and not os.getenv("ANTHROPIC_API_KEY"):
+    client = Anthropic(base_url=os.getenv("ANTHROPIC_BASE_URL"), auth_token=os.getenv("ANTHROPIC_AUTH_TOKEN"))
+elif os.getenv("ANTHROPIC_API_KEY") and not os.getenv("ANTHROPIC_BASE_URL") and not os.getenv("ANTHROPIC_AUTH_TOKEN"):
+    client = Anthropic(api_key=os.getenv("ANTHROPIC_API_KEY"))
 
 WORKDIR = Path.cwd()
-client = Anthropic(base_url=os.getenv("ANTHROPIC_BASE_URL"))
 MODEL = os.environ["MODEL_ID"]
 
 SYSTEM = f"You are a coding agent at {WORKDIR}. Use background_run for long-running commands."

--- a/agents/s09_agent_teams.py
+++ b/agents/s09_agent_teams.py
@@ -54,11 +54,14 @@ from anthropic import Anthropic
 from dotenv import load_dotenv
 
 load_dotenv(override=True)
-if os.getenv("ANTHROPIC_BASE_URL"):
-    os.environ.pop("ANTHROPIC_AUTH_TOKEN", None)
+
+# using either ANTHROPIC_BASE_URL + ANTHROPIC_AUTH_TOKEN or ANTHROPIC_API_KEY is supported
+if os.getenv("ANTHROPIC_BASE_URL") and os.getenv("ANTHROPIC_AUTH_TOKEN") and not os.getenv("ANTHROPIC_API_KEY"):
+    client = Anthropic(base_url=os.getenv("ANTHROPIC_BASE_URL"), auth_token=os.getenv("ANTHROPIC_AUTH_TOKEN"))
+elif os.getenv("ANTHROPIC_API_KEY") and not os.getenv("ANTHROPIC_BASE_URL") and not os.getenv("ANTHROPIC_AUTH_TOKEN"):
+    client = Anthropic(api_key=os.getenv("ANTHROPIC_API_KEY"))
 
 WORKDIR = Path.cwd()
-client = Anthropic(base_url=os.getenv("ANTHROPIC_BASE_URL"))
 MODEL = os.environ["MODEL_ID"]
 TEAM_DIR = WORKDIR / ".team"
 INBOX_DIR = TEAM_DIR / "inbox"

--- a/agents/s10_team_protocols.py
+++ b/agents/s10_team_protocols.py
@@ -59,11 +59,14 @@ from anthropic import Anthropic
 from dotenv import load_dotenv
 
 load_dotenv(override=True)
-if os.getenv("ANTHROPIC_BASE_URL"):
-    os.environ.pop("ANTHROPIC_AUTH_TOKEN", None)
+
+# using either ANTHROPIC_BASE_URL + ANTHROPIC_AUTH_TOKEN or ANTHROPIC_API_KEY is supported
+if os.getenv("ANTHROPIC_BASE_URL") and os.getenv("ANTHROPIC_AUTH_TOKEN") and not os.getenv("ANTHROPIC_API_KEY"):
+    client = Anthropic(base_url=os.getenv("ANTHROPIC_BASE_URL"), auth_token=os.getenv("ANTHROPIC_AUTH_TOKEN"))
+elif os.getenv("ANTHROPIC_API_KEY") and not os.getenv("ANTHROPIC_BASE_URL") and not os.getenv("ANTHROPIC_AUTH_TOKEN"):
+    client = Anthropic(api_key=os.getenv("ANTHROPIC_API_KEY"))
 
 WORKDIR = Path.cwd()
-client = Anthropic(base_url=os.getenv("ANTHROPIC_BASE_URL"))
 MODEL = os.environ["MODEL_ID"]
 TEAM_DIR = WORKDIR / ".team"
 INBOX_DIR = TEAM_DIR / "inbox"

--- a/agents/s11_autonomous_agents.py
+++ b/agents/s11_autonomous_agents.py
@@ -47,11 +47,14 @@ from anthropic import Anthropic
 from dotenv import load_dotenv
 
 load_dotenv(override=True)
-if os.getenv("ANTHROPIC_BASE_URL"):
-    os.environ.pop("ANTHROPIC_AUTH_TOKEN", None)
+
+# using either ANTHROPIC_BASE_URL + ANTHROPIC_AUTH_TOKEN or ANTHROPIC_API_KEY is supported
+if os.getenv("ANTHROPIC_BASE_URL") and os.getenv("ANTHROPIC_AUTH_TOKEN") and not os.getenv("ANTHROPIC_API_KEY"):
+    client = Anthropic(base_url=os.getenv("ANTHROPIC_BASE_URL"), auth_token=os.getenv("ANTHROPIC_AUTH_TOKEN"))
+elif os.getenv("ANTHROPIC_API_KEY") and not os.getenv("ANTHROPIC_BASE_URL") and not os.getenv("ANTHROPIC_AUTH_TOKEN"):
+    client = Anthropic(api_key=os.getenv("ANTHROPIC_API_KEY"))
 
 WORKDIR = Path.cwd()
-client = Anthropic(base_url=os.getenv("ANTHROPIC_BASE_URL"))
 MODEL = os.environ["MODEL_ID"]
 TEAM_DIR = WORKDIR / ".team"
 INBOX_DIR = TEAM_DIR / "inbox"

--- a/agents/s12_worktree_task_isolation.py
+++ b/agents/s12_worktree_task_isolation.py
@@ -42,11 +42,13 @@ from dotenv import load_dotenv
 
 load_dotenv(override=True)
 
-if os.getenv("ANTHROPIC_BASE_URL"):
-    os.environ.pop("ANTHROPIC_AUTH_TOKEN", None)
+# using either ANTHROPIC_BASE_URL + ANTHROPIC_AUTH_TOKEN or ANTHROPIC_API_KEY is supported
+if os.getenv("ANTHROPIC_BASE_URL") and os.getenv("ANTHROPIC_AUTH_TOKEN") and not os.getenv("ANTHROPIC_API_KEY"):
+    client = Anthropic(base_url=os.getenv("ANTHROPIC_BASE_URL"), auth_token=os.getenv("ANTHROPIC_AUTH_TOKEN"))
+elif os.getenv("ANTHROPIC_API_KEY") and not os.getenv("ANTHROPIC_BASE_URL") and not os.getenv("ANTHROPIC_AUTH_TOKEN"):
+    client = Anthropic(api_key=os.getenv("ANTHROPIC_API_KEY"))
 
 WORKDIR = Path.cwd()
-client = Anthropic(base_url=os.getenv("ANTHROPIC_BASE_URL"))
 MODEL = os.environ["MODEL_ID"]
 
 

--- a/agents/s_full.py
+++ b/agents/s_full.py
@@ -50,11 +50,14 @@ from anthropic import Anthropic
 from dotenv import load_dotenv
 
 load_dotenv(override=True)
-if os.getenv("ANTHROPIC_BASE_URL"):
-    os.environ.pop("ANTHROPIC_AUTH_TOKEN", None)
+
+# using either ANTHROPIC_BASE_URL + ANTHROPIC_AUTH_TOKEN or ANTHROPIC_API_KEY is supported
+if os.getenv("ANTHROPIC_BASE_URL") and os.getenv("ANTHROPIC_AUTH_TOKEN") and not os.getenv("ANTHROPIC_API_KEY"):
+    client = Anthropic(base_url=os.getenv("ANTHROPIC_BASE_URL"), auth_token=os.getenv("ANTHROPIC_AUTH_TOKEN"))
+elif os.getenv("ANTHROPIC_API_KEY") and not os.getenv("ANTHROPIC_BASE_URL") and not os.getenv("ANTHROPIC_AUTH_TOKEN"):
+    client = Anthropic(api_key=os.getenv("ANTHROPIC_API_KEY"))
 
 WORKDIR = Path.cwd()
-client = Anthropic(base_url=os.getenv("ANTHROPIC_BASE_URL"))
 MODEL = os.environ["MODEL_ID"]
 
 TEAM_DIR = WORKDIR / ".team"


### PR DESCRIPTION
## Summary
Per official SDK documentation:
- `ANTHROPIC_API_KEY` for Anthropic API
- `ANTHROPIC_BASE_URL` + `ANTHROPIC_AUTH_TOKEN` for third-party endpoints

Previous code incorrectly popped `ANTHROPIC_AUTH_TOKEN` when `ANTHROPIC_BASE_URL` was set, which broke third-party authentication. Now strictly separates the two authentication methods with explicit conditionals.

## Changes
Updated all 13 agent harness files (s01-s12, s_full):
- Removed incorrect `os.environ.pop("ANTHROPIC_AUTH_TOKEN", None)` logic
- Added explicit conditional initialization for both auth methods
- Removed duplicate `client = Anthropic(base_url=...)` that overrode conditional logic

## Test plan
- [x] Test with `ANTHROPIC_API_KEY` only → connects to Anthropic API
- [x] Test with `ANTHROPIC_BASE_URL` + `ANTHROPIC_AUTH_TOKEN` → connects to third-party endpoint
- [x] Verify scripts fail gracefully when neither auth method is configured