### PR TITLE
Fix unhandled OSError in subprocess and unsafe dict access in subagent

### DIFF
--- a/agents/s01_agent_loop.py
+++ b/agents/s01_agent_loop.py
@@ -73,6 +73,8 @@ def run_bash(command: str) -> str:
         return out[:50000] if out else "(no output)"
     except subprocess.TimeoutExpired:
         return "Error: Timeout (120s)"
+    except (FileNotFoundError, OSError) as e:
+        return f"Error: {e}"
 
 
 # -- The core pattern: a while loop that calls tools until the model stops --

--- a/agents/s04_subagent.py
+++ b/agents/s04_subagent.py
@@ -61,6 +61,8 @@ def run_bash(command: str) -> str:
         return out[:50000] if out else "(no output)"
     except subprocess.TimeoutExpired:
         return "Error: Timeout (120s)"
+    except (FileNotFoundError, OSError) as e:
+        return f"Error: {e}"
 
 def run_read(path: str, limit: int = None) -> str:
     try:
@@ -155,8 +157,9 @@ def agent_loop(messages: list):
             if block.type == "tool_use":
                 if block.name == "task":
                     desc = block.input.get("description", "subtask")
-                    print(f"> task ({desc}): {block.input['prompt'][:80]}")
-                    output = run_subagent(block.input["prompt"])
+                    prompt = block.input.get("prompt", "")
+                    print(f"> task ({desc}): {prompt[:80]}")
+                    output = run_subagent(prompt)
                 else:
                     handler = TOOL_HANDLERS.get(block.name)
                     output = handler(**block.input) if handler else f"Unknown tool: {block.name}"


### PR DESCRIPTION
## Summary

- **`agents/s01_agent_loop.py`**: `run_bash()` only catches `TimeoutExpired` but not `FileNotFoundError`/`OSError`, which can crash the agent loop when the shell executable is missing or command path is invalid
- **`agents/s04_subagent.py`**: Same subprocess fix + changed `block.input['prompt']` to `block.input.get("prompt", "")` for consistency with `block.input.get("description", "subtask")` already used on line 157

## Test plan
- [x] Verified fix handles `FileNotFoundError` gracefully instead of crashing
- [x] Consistent `.get()` usage across tool input access patterns

🤖 Generated with [Claude Code](https://claude.com/claude-code)