### PR TITLE
feat: add Dockerfile and docker-compose for containerized deployment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,41 @@
+# Git
+.git
+.gitignore
+
+# Docker files (not needed inside image)
+Dockerfile
+docker-compose*.yml
+.dockerignore
+
+# Environment files (should be passed via env_file)
+.env
+.env.*
+!.env.example
+
+# Node.js build artifacts
+web/.next
+web/node_modules
+
+# Python cache
+__pycache__
+*.py[cod]
+*.egg-info
+.eggs
+.pytest_cache
+
+# Docs
+*.md
+!README.md
+docs
+
+# Tests (keep tests dir but skip heavy test files)
+tests
+
+# OS
+.DS_Store
+Thumbs.db
+
+# IDE
+.vscode
+.idea
+*.swp

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,71 @@
+# =============================================================================
+# learn-claude-code Dockerfile
+# =============================================================================
+# Multi-stage build: builds both the Next.js web frontend and Python agents.
+# Usage:
+#   docker build -t learn-claude-code .
+#   docker run -d -p 3000:3000 --env-file .env learn-claude-code
+#
+# For agents only:
+#   docker run -d --env-file .env learn-claude-code python agents/s_full.py
+# =============================================================================
+
+# ── Stage 1: Python agents ──────────────────────────────────────────────────
+FROM python:3.11-slim AS agents
+
+WORKDIR /app
+
+# Install dependencies
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy agent and skills code
+COPY agents/ ./agents/
+COPY skills/  ./skills/
+
+ENV PYTHONPATH=/app
+
+# ── Stage 2: Node.js web ─────────────────────────────────────────────────────
+FROM node:22-alpine AS web
+
+WORKDIR /app/web
+
+# Install Next.js dependencies
+COPY web/package*.json ./
+RUN npm ci
+
+# Copy Next.js source
+COPY web/ ./
+
+# Build (pre-run extract script via tsx)
+RUN npm run extract && npm run build
+
+# ── Stage 3: Runtime ──────────────────────────────────────────────────────────
+FROM python:3.11-slim AS runtime
+
+WORKDIR /app
+
+# Install runtime deps for web server
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    nodejs \
+    npm \
+    curl \
+    && rm -rf /var/lib/apt/lists/*
+
+# Copy Python agents from stage 1
+COPY --from=agents /usr/local/lib/python3.11/site-packages /usr/local/lib/python3.11/site-packages
+COPY --from=agents /app/agents    /app/agents
+COPY --from=agents /app/skills   /app/skills
+COPY --from=agents /app/requirements.txt /app/
+
+# Copy built Next.js from stage 2
+COPY --from=web /app/web/.next   /app/web/.next
+COPY --from=web /app/web/public  /app/web/public
+COPY --from=web /app/web/node_modules /app/web/node_modules
+COPY --from=web /app/web/package.json  /app/web/package.json
+
+ENV PYTHONPATH=/app
+ENV WEB_DIR=/app/web
+
+# Default command: run web server
+CMD ["sh", "-c", "cd $WEB_DIR && npm start"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,84 @@
+# =============================================================================
+# learn-claude-code docker-compose.yml
+# =============================================================================
+# Start the full stack (web + agents):
+#   cp .env.example .env
+#   # edit .env and fill in your ANTHROPIC_API_KEY
+#   docker-compose up -d
+#
+# Start web only:
+#   docker-compose up -d web
+#
+# Start agents only:
+#   docker-compose up -d agents
+#
+# Tail logs:
+#   docker-compose logs -f
+# =============================================================================
+
+services:
+  # ── Next.js Web Frontend ──────────────────────────────────────────────────
+  web:
+    build:
+      context: .
+      target: runtime
+    container_name: learn-claude-code-web
+    restart: unless-stopped
+    ports:
+      - "3000:3000"
+    env_file:
+      - .env
+    volumes:
+      # Hot-reload support during development
+      - ./web/src:/app/web/src:ro
+      - ./web/public:/app/web/public:ro
+    environment:
+      - WEB_DIR=/app/web
+      - PYTHONPATH=/app
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:3000"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 20s
+    depends_on:
+      - agents
+
+  # ── Python Agents ─────────────────────────────────────────────────────────
+  agents:
+    build:
+      context: .
+      target: agents
+    container_name: learn-claude-code-agents
+    restart: unless-stopped
+    env_file:
+      - .env
+    volumes:
+      # Mount agents and skills for development hot-reload
+      - ./agents:/app/agents:ro
+      - ./skills:/app/skills:ro
+    environment:
+      - PYTHONPATH=/app
+    command: ["python", "agents/s_full.py"]
+
+  # ── Optional: Jupyter for interactive development ─────────────────────────
+  jupyter:
+    build:
+      context: .
+      target: agents
+    container_name: learn-claude-code-jupyter
+    restart: no
+    ports:
+      - "8888:8888"
+    env_file:
+      - .env
+    volumes:
+      - ./agents:/app/agents:ro
+      - ./skills:/app/skills:ro
+    environment:
+      - PYTHONPATH=/app
+    command: ["jupyter", "notebook", "--ip=0.0.0.0", "--port=8888", "--no-browser", "--allow-root"]
+
+networks:
+  default:
+    name: learn-claude-code-net


### PR DESCRIPTION
## Summary
Adds Docker support so the project can be run in a containerized environment.

## Changes
- **Dockerfile**: Multi-stage build that compiles the Next.js web frontend and sets up the Python agents runtime. Supports three usage modes:
  - Full stack: `docker build -t learn-claude-code . && docker run -p 3000:3000 --env-file .env learn-claude-code`
  - Agents only: `docker run --env-file .env learn-claude-code python agents/s_full.py`
  - Jupyter (optional): for interactive development

- **docker-compose.yml**: Orchestrates the full stack with three services:
  - `web`: Next.js frontend on port 3000
  - `agents`: Python agents (default entrypoint: \`python agents/s_full.py\`)
  - `jupyter` (optional): Jupyter notebook on port 8888

- **.dockerignore**: Keeps the image clean by excluding build artifacts, cache, and sensitive files.

## Usage
```bash
cp .env.example .env
# Fill in ANTHROPIC_API_KEY in .env
docker-compose up -d
```

Then open http://localhost:3000.