### PR TITLE
fix: resolve inability to call shutdown_response tool (S11)

### DIFF
--- a/agents/s11_autonomous_agents.py
+++ b/agents/s11_autonomous_agents.py
@@ -254,6 +254,8 @@ class TeammateManager:
                             output = "Entering idle phase. Will poll for new tasks."
                         else:
                             output = self._exec(name, block.name, block.input)
+                            if block.name == "shutdown_response" and block.input.get("approve"):
+                                return
                         print(f"  [{name}] {block.name}: {str(output)[:120]}")
                         results.append({
                             "type": "tool_result",
@@ -273,9 +275,6 @@ class TeammateManager:
                 inbox = BUS.read_inbox(name)
                 if inbox:
                     for msg in inbox:
-                        if msg.get("type") == "shutdown_request":
-                            self._set_status(name, "shutdown")
-                            return
                         messages.append({"role": "user", "content": json.dumps(msg)})
                     resume = True
                     break
@@ -325,6 +324,8 @@ class TeammateManager:
                 sender, "lead", args.get("reason", ""),
                 "shutdown_response", {"request_id": req_id, "approve": args["approve"]},
             )
+            if args["approve"]:
+                self._set_status(sender, "shutdown")
             return f"Shutdown {'approved' if args['approve'] else 'rejected'}"
         if tool_name == "plan_approval":
             plan_text = args.get("plan", "")


### PR DESCRIPTION
fix: resolve inability to call shutdown_response tool (S11)

Previously, autonomous agents in the IDLE phase would hard-kill themselves (via an immediate return) upon receiving a `shutdown_request` message. This bypassed the agent's LLM completely, preventing it from using the `shutdown_response` tool to formally approve or reject the request.

This commit fixes the issue by:
1. Removing the early return in the inbox polling loop so the `shutdown_request` message is correctly appended to the agent's context and wakes it up.
2. Updating the `shutdown_response` tool handler to mark the agent's status as "shutdown" if `approve` is True.
3. Breaking the agent's main loop if `shutdown_response` is called and approved, allowing the thread to terminate gracefully.

This restores the intended collaborative negotiation mechanism between the Lead and Teammate agents.