### PR TITLE
fix(s06): pass compact tool's focus param to auto_compact summarization

### DIFF
--- a/agents/s06_context_compact.py
+++ b/agents/s06_context_compact.py
@@ -100,7 +100,7 @@ def micro_compact(messages: list) -> list:
 
 
 # -- Layer 2: auto_compact - save transcript, summarize, replace messages --
-def auto_compact(messages: list) -> list:
+def auto_compact(messages: list, focus: str = "") -> list:
     # Save full transcript to disk
     TRANSCRIPT_DIR.mkdir(exist_ok=True)
     transcript_path = TRANSCRIPT_DIR / f"transcript_{int(time.time())}.jsonl"
@@ -110,12 +110,14 @@ def auto_compact(messages: list) -> list:
     print(f"[transcript saved: {transcript_path}]")
     # Ask LLM to summarize
     conversation_text = json.dumps(messages, default=str)[-80000:]
+    focus_instruction = f"\nIMPORTANT: Pay special attention to preserving details about: {focus}" if focus else ""
     response = client.messages.create(
         model=MODEL,
         messages=[{"role": "user", "content":
             "Summarize this conversation for continuity. Include: "
             "1) What was accomplished, 2) Current state, 3) Key decisions made. "
-            "Be concise but preserve critical details.\n\n" + conversation_text}],
+            "Be concise but preserve critical details."
+            f"{focus_instruction}\n\n" + conversation_text}],
         max_tokens=2000,
     )
     summary = next((block.text for block in response.content if hasattr(block, "text")), "")
@@ -215,11 +217,13 @@ def agent_loop(messages: list):
             return
         results = []
         manual_compact = False
+        compact_focus = ""
         for block in response.content:
             if block.type == "tool_use":
                 if block.name == "compact":
                     manual_compact = True
-                    output = "Compressing..."
+                    compact_focus = block.input.get("focus", "")
+                    output = "Compressing..." + (f" (focus: {compact_focus})" if compact_focus else "")
                 else:
                     handler = TOOL_HANDLERS.get(block.name)
                     try:
@@ -232,8 +236,8 @@ def agent_loop(messages: list):
         messages.append({"role": "user", "content": results})
         # Layer 3: manual compact triggered by the compact tool
         if manual_compact:
-            print("[manual compact]")
-            messages[:] = auto_compact(messages)
+            print(f"[manual compact{': ' + compact_focus if compact_focus else ''}]")
+            messages[:] = auto_compact(messages, focus=compact_focus)
             return
 
 


### PR DESCRIPTION
### What
将 compact 工具的 focus 参数贯穿到实际的摘要压缩流程中。
### Why
s06_context_compact.py 中的 compact 工具定义了 focus 入参，但之前这个参数从未被实际使用——auto_compact 函数既不接收也不处理它，导致 LLM 在压缩对话时无法做到有针对性的保留。
### Changes
传递focus参数给LLM模型，引导 LLM 重点保留用户关心的内容。