### PR TITLE
Added ollama provider example in .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -59,3 +59,13 @@ MODEL_ID=claude-sonnet-4-6
 # DeepSeek (no regional split, same endpoint globally)
 # ANTHROPIC_BASE_URL=https://api.deepseek.com/anthropic
 # MODEL_ID=deepseek-chat
+
+
+# =============================================================================
+
+# Ollama provided models through cloud/local. Make sure ollama is running
+
+# ANTHROPIC_API_KEY=your-ollama-api-key         # ollama api key
+# ANTHROPIC_BASE_URL=http://localhost:11434     # Ollama's default port (keep as is unless you run from different port)
+# ANTHROPIC_AUTH_TOKEN=ollama                   # keep as is
+# MODEL_ID=minimax-m2.1:cloud                   # your model name


### PR DESCRIPTION
Current examples don't show how ollama models can be used for this great learning repo. Added example of how to use it with ollama without changing any thing else. Ollama support anthropic and openai endpoints. 
Details at https://docs.ollama.com/integrations/claude-code