### PR TITLE
fix: add missing "> /dev/" dangerous command check in s09/s10/s11

### DIFF
--- a/agents/s09_agent_teams.py
+++ b/agents/s09_agent_teams.py
@@ -260,7 +260,7 @@ def _safe_path(p: str) -> Path:
 
 
 def _run_bash(command: str) -> str:
-    dangerous = ["rm -rf /", "sudo", "shutdown", "reboot"]
+    dangerous = ["rm -rf /", "sudo", "shutdown", "reboot", "> /dev/"]
     if any(d in command for d in dangerous):
         return "Error: Dangerous command blocked"
     try:

--- a/agents/s10_team_protocols.py
+++ b/agents/s10_team_protocols.py
@@ -301,7 +301,7 @@ def _safe_path(p: str) -> Path:
 
 
 def _run_bash(command: str) -> str:
-    dangerous = ["rm -rf /", "sudo", "shutdown", "reboot"]
+    dangerous = ["rm -rf /", "sudo", "shutdown", "reboot", "> /dev/"]
     if any(d in command for d in dangerous):
         return "Error: Dangerous command blocked"
     try:

--- a/agents/s11_autonomous_agents.py
+++ b/agents/s11_autonomous_agents.py
@@ -389,7 +389,7 @@ def _safe_path(p: str) -> Path:
 
 
 def _run_bash(command: str) -> str:
-    dangerous = ["rm -rf /", "sudo", "shutdown", "reboot"]
+    dangerous = ["rm -rf /", "sudo", "shutdown", "reboot", "> /dev/"]
     if any(d in command for d in dangerous):
         return "Error: Dangerous command blocked"
     try:


### PR DESCRIPTION
## Summary

- `s09_agent_teams.py`, `s10_team_protocols.py`, and `s11_autonomous_agents.py` are missing the `"> /dev/"` entry in their `_run_bash()` dangerous command blocklist
- This is present in s01, s06, s12, and s_full but was dropped when s09–s11 were written, creating a security regression where commands like `echo y > /dev/sda` could bypass the blocklist

## Changes

| File | Change |
|------|--------|
| `agents/s09_agent_teams.py` | Added `"> /dev/"` to dangerous list in `_run_bash()` |
| `agents/s10_team_protocols.py` | Added `"> /dev/"` to dangerous list in `_run_bash()` |
| `agents/s11_autonomous_agents.py` | Added `"> /dev/"` to dangerous list in `_run_bash()` |

## Test plan

- [x] `python -m py_compile agents/s09_agent_teams.py` passes
- [x] `python -m py_compile agents/s10_team_protocols.py` passes
- [x] `python -m py_compile agents/s11_autonomous_agents.py` passes
- [x] Verified blocklist now matches s01/s06/s12/s_full