### PR TITLE
fix: 修复 s07 reminder 注入破坏 tool_result 顺序的问题

### DIFF
--- a/s07_skill_loading/code.py
+++ b/s07_skill_loading/code.py
@@ -344,13 +344,10 @@ def agent_loop(messages: list):
     global rounds_since_todo
     while True:
         if rounds_since_todo >= 3 and messages:
-            last = messages[-1]
-            if last["role"] == "user" and isinstance(last.get("content"), list):
-                last["content"].insert(0, {
-                    "type": "text",
-                    "text": "<reminder>Update your todos.</reminder>",
-                })
-
+            messages.append({"role": "user",
+                             "content": "<reminder>Update your todos.</reminder>"})
+            rounds_since_todo = 0
+            
         response = client.messages.create(
             model=MODEL, system=SYSTEM, messages=messages,
             tools=TOOLS, max_tokens=8000,


### PR DESCRIPTION
## 背景

`s07_skill_loading/code.py` 中的 reminder 注入逻辑会在特定情况下修改上一条 user 消息内容。相关代码在 `agent_loop()` 中（347-352 行）：

```python
if rounds_since_todo >= 3 and messages:
    last = messages[-1]
    if last["role"] == "user" and isinstance(last.get("content"), list):
        last["content"].insert(0, {
            "type": "text",
            "text": "<reminder>Update your todos.</reminder>",
        })
```

当上一条 user 消息本身是工具调用返回的 `tool_result` 列表时，当前实现会在列表最前面插入一条普通 `text` block，导致 `tool_result` 不再紧跟对应的 `tool_use`，从而触发 API 校验错误。

## 问题表现

在执行多轮工具调用后，可能出现类似报错：

```text
BadRequestError: `tool_use` ids were found without `tool_result` blocks immediately after
```

## 修复方式

采用 `s06` 的方法，将 reminder 改为追加一条独立的 user 消息，而不是修改已有的 `tool_result` 消息内容。

修复后可以保持工具调用消息结构稳定，不会再破坏 `tool_use -> tool_result` 的顺序约束：

```python
messages.append({
    "role": "user",
    "content": "<reminder>Update your todos.</reminder>",
})
rounds_since_todo = 0
```