### PR TITLE
fix: 修复 s09 memory pipeline 无法处理非 text 响应块的问题

### DIFF
--- a/s07_skill_loading/code.py
+++ b/s07_skill_loading/code.py
@@ -344,13 +344,10 @@ def agent_loop(messages: list):
     global rounds_since_todo
     while True:
         if rounds_since_todo >= 3 and messages:
-            last = messages[-1]
-            if last["role"] == "user" and isinstance(last.get("content"), list):
-                last["content"].insert(0, {
-                    "type": "text",
-                    "text": "<reminder>Update your todos.</reminder>",
-                })
-
+            messages.append({"role": "user",
+                             "content": "<reminder>Update your todos.</reminder>"})
+            rounds_since_todo = 0
+            
         response = client.messages.create(
             model=MODEL, system=SYSTEM, messages=messages,
             tools=TOOLS, max_tokens=8000,

--- a/s09_memory/code.py
+++ b/s09_memory/code.py
@@ -128,6 +128,44 @@ def list_memory_files() -> list[dict]:
         })
     return result
 
+def _memory_signature(mem: dict) -> tuple[str, str, str]:
+    return (
+        str(mem.get("name", "")).strip().lower(),
+        str(mem.get("description", "")).strip().lower(),
+        str(mem.get("body", "")).strip().lower(),
+    )
+
+def _response_text(blocks) -> str:
+    parts = []
+    for block in blocks:
+        if getattr(block, "type", None) == "text":
+            parts.append(getattr(block, "text", ""))
+    return "\n".join(p for p in parts if p).strip()
+
+
+def _store_memories(items: list[dict], existing: list[dict] | None = None) -> int:
+    existing = existing if existing is not None else list_memory_files()
+    seen = {_memory_signature(mem) for mem in existing}
+    count = 0
+
+    for mem in items:
+        name = str(mem.get("name", "")).strip() or f"memory-{int(time.time())}"
+        mem_type = mem.get("type", "user")
+        desc = str(mem.get("description", "")).strip()
+        body = str(mem.get("body", "")).strip()
+        if mem_type not in MEMORY_TYPES or not desc or not body:
+            continue
+
+        sig = _memory_signature({"name": name, "description": desc, "body": body})
+        if sig in seen:
+            continue
+
+        write_memory_file(name, mem_type, desc, body)
+        seen.add(sig)
+        count += 1
+
+    return count
+
 
 def select_relevant_memories(messages: list, max_items: int = 5) -> list[str]:
     """Select relevant memory filenames by matching recent conversation against
@@ -177,7 +215,7 @@ def select_relevant_memories(messages: list, max_items: int = 5) -> list[str]:
             messages=[{"role": "user", "content": prompt}],
             max_tokens=200,
         )
-        text = response.content[0].text.strip()
+        text = _response_text(response.content)
         # Extract JSON array from response
         match = re.search(r'\[.*?\]', text, re.DOTALL)
         if match:
@@ -238,7 +276,6 @@ def extract_memories(messages: list):
     if not dialogue.strip():
         return
 
-    # Check existing memories to avoid duplicates
     existing = list_memory_files()
     existing_desc = "\n".join(f"- {m['name']}: {m['description']}" for m in existing) if existing else "(none)"
 
@@ -259,27 +296,20 @@ def extract_memories(messages: list):
         response = client.messages.create(
             model=MODEL, messages=[{"role": "user", "content": prompt}], max_tokens=800
         )
-        text = response.content[0].text.strip()
+        text = _response_text(response.content)
         # Extract JSON array from response
         match = re.search(r'\[.*\]', text, re.DOTALL)
         if not match:
+            print("\033[90m[Memory: no JSON returned by extractor]\033[0m")
             return
         items = json.loads(match.group())
         if not items:
             return
-        count = 0
-        for mem in items:
-            name = mem.get("name", f"memory_{int(time.time())}")
-            mem_type = mem.get("type", "user")
-            desc = mem.get("description", "")
-            body = mem.get("body", "")
-            if desc and body:
-                write_memory_file(name, mem_type, desc, body)
-                count += 1
+        count = _store_memories(items, existing=existing)
         if count:
-            print(f"\n\033[33m[Memory: extracted {count} new memories]\033[0m")
-    except Exception:
-        pass
+            print(f"\n\033[33m[Memory: llm-extracted {count} new memories]\033[0m")
+    except Exception as e:
+        print(f"\033[31m[Memory extraction failed] {e}\033[0m")
 
 
 CONSOLIDATE_THRESHOLD = 10
@@ -309,7 +339,7 @@ def consolidate_memories():
         response = client.messages.create(
             model=MODEL, messages=[{"role": "user", "content": prompt}], max_tokens=3000
         )
-        text = response.content[0].text.strip()
+        text = _response_text(response.content)
         match = re.search(r'\[.*\]', text, re.DOTALL)
         if not match:
             return


### PR DESCRIPTION
## 问题背景

`s09_memory/code.py` 中的记忆流程在多个位置直接读取 `response.content[0].text`。当模型返回的第一个 block 不是 text，而是 `ThinkingBlock` 等其他类型时，会直接抛错，导致记忆选择、记忆抽取或记忆合并流程中断。

相关逻辑原本类似：

```python
text = response.content[0].text.strip()
```

由于记忆抽取流程中断，后续不会继续执行 `.memory/*.md` 写入和 `MEMORY.md` 索引更新，因此表现上会出现“助手说记住了，但实际没有写入记忆”的情况。

## 问题表现

运行过程中可能出现类似报错：

```text
[Memory extraction failed] 'ThinkingBlock' object has no attribute 'text'
```

出现该问题后，记忆内容无法正常写入 `.memory/`，也无法被后续对话正确加载。

## 修复方式

本次修复将响应内容读取方式改为统一提取所有 `text` block，而不是假设第一个 block 一定带有 `.text` 属性。

修复后即使模型返回 `ThinkingBlock` 或其他非 text block，记忆流程仍然可以继续完成文本提取、结果解析、记忆写入和索引更新：

```python
def _response_text(blocks) -> str:
    parts = []
    for block in blocks:
        if getattr(block, "type", None) == "text":
            parts.append(getattr(block, "text", ""))
    return "\n".join(p for p in parts if p).strip()
```