### PR TITLE
fix: prevent s09 memory preview overflow

### DIFF
--- a/web/src/components/visualizations/s09-memory.tsx
+++ b/web/src/components/visualizations/s09-memory.tsx
@@ -340,7 +340,7 @@ export default function MemoryVisualization({ title }: { title?: string }) {
                 Memory file preview
               </div>
               {step >= 2 ? (
-                <div className="grid gap-3 lg:grid-cols-[minmax(0,1.15fr)_minmax(220px,0.85fr)]">
+                <div className="grid gap-3">
                   <MemoryDetail file={selectedFile} selected={selected} />
                   <div className="space-y-2">
                     {MEMORY_FILES.slice(1).map((file) => (


### PR DESCRIPTION
## Summary
- Remove the nested desktop two-column layout from the s09 Memory file preview
- Keep the selected memory detail card at full preview-column width so its title does not wrap vertically

## Verification
- npm run build
- Browser checked `/zh/s09` at the affected step and confirmed `Beginner visual preference` no longer stacks vertically