### PR TITLE
fix: prevent course SVG text overflow

### DIFF
--- a/s08_context_compact/images/auto-compact.en.svg
+++ b/s08_context_compact/images/auto-compact.en.svg
@@ -22,10 +22,10 @@
   <!-- Steps -->
   <rect x="20" y="106" width="200" height="110" rx="8" fill="#fff" stroke="#94a3b8" stroke-width="1.5"/>
   <text x="120" y="130" fill="#1e3a5f" font-size="12" font-weight="700" text-anchor="middle">Step 1: Save transcript</text>
-  <text x="40" y="152" fill="#475569" font-size="10">Write full conversation to .transcripts/</text>
-  <text x="40" y="168" fill="#475569" font-size="10">JSONL format, one message per line</text>
-  <text x="40" y="184" fill="#475569" font-size="10">Filename: transcript_{timestamp}.jsonl</text>
-  <text x="40" y="200" fill="#94a3b8" font-size="9">No data lost, just moved out of active area</text>
+  <text x="40" y="152" fill="#475569" font-size="10">Write conversation to .transcripts/</text>
+  <text x="40" y="168" fill="#475569" font-size="10">One JSONL message per line</text>
+  <text x="40" y="184" fill="#475569" font-size="10">File: transcript_{time}.jsonl</text>
+  <text x="40" y="200" fill="#94a3b8" font-size="9">Full transcript stays on disk</text>
 
   <line x1="225" y1="161" x2="265" y2="161" stroke="#dc2626" stroke-width="2" marker-end="url(#arrow)"/>
 
@@ -33,9 +33,9 @@
   <text x="370" y="130" fill="#1e3a5f" font-size="12" font-weight="700" text-anchor="middle">Step 2: LLM generates summary</text>
   <text x="290" y="152" fill="#475569" font-size="10">Send conversation history to LLM</text>
   <text x="290" y="166" fill="#475569" font-size="9">Summary must include 9 sections:</text>
-  <text x="290" y="180" fill="#94a3b8" font-size="8">request · concepts · files · errors · resolutions</text>
-  <text x="290" y="192" fill="#94a3b8" font-size="8">user messages · todos · current state · next steps</text>
-  <text x="290" y="206" fill="#94a3b8" font-size="9">Generated only once</text>
+  <text x="370" y="180" fill="#94a3b8" font-size="8" text-anchor="middle">request · concepts · files · errors</text>
+  <text x="370" y="192" fill="#94a3b8" font-size="8" text-anchor="middle">resolutions · user messages · todos</text>
+  <text x="370" y="204" fill="#94a3b8" font-size="8" text-anchor="middle">current state · next steps</text>
 
   <line x1="475" y1="161" x2="515" y2="161" stroke="#dc2626" stroke-width="2" marker-end="url(#arrow)"/>
 

--- a/s08_context_compact/images/auto-compact.ja.svg
+++ b/s08_context_compact/images/auto-compact.ja.svg
@@ -24,8 +24,8 @@
   <text x="120" y="130" fill="#1e3a5f" font-size="12" font-weight="700" text-anchor="middle">ステップ 1：transcript 保存</text>
   <text x="40" y="152" fill="#475569" font-size="10">完全な対話を .transcripts/ に書き込み</text>
   <text x="40" y="168" fill="#475569" font-size="10">JSONL 形式、1 行 1 メッセージ</text>
-  <text x="40" y="184" fill="#475569" font-size="10">ファイル名：transcript_{timestamp}.jsonl</text>
-  <text x="40" y="200" fill="#94a3b8" font-size="9">情報は失われていない、アクティブ領域から移動のみ</text>
+  <text x="40" y="184" fill="#475569" font-size="10">transcript_{time}.jsonl</text>
+  <text x="40" y="200" fill="#94a3b8" font-size="9">内容はディスクに残る</text>
 
   <line x1="225" y1="161" x2="265" y2="161" stroke="#dc2626" stroke-width="2" marker-end="url(#arrow)"/>
 
@@ -40,10 +40,10 @@
   <line x1="475" y1="161" x2="515" y2="161" stroke="#dc2626" stroke-width="2" marker-end="url(#arrow)"/>
 
   <rect x="520" y="106" width="180" height="110" rx="8" fill="#fef2f2" stroke="#dc2626" stroke-width="2"/>
-  <text x="610" y="130" fill="#991b1b" font-size="12" font-weight="700" text-anchor="middle">ステップ 3：メッセージリスト置換</text>
+  <text x="610" y="130" fill="#991b1b" font-size="12" font-weight="700" text-anchor="middle">ステップ 3：要約に置換</text>
   <text x="540" y="152" fill="#991b1b" font-size="10">全旧メッセージ → 1 件の要約に</text>
   <text x="540" y="168" fill="#991b1b" font-size="10">モデルは要約から作業を継続</text>
-  <text x="540" y="184" fill="#991b1b" font-size="10">recently_read ファイルリストを付与</text>
+  <text x="540" y="184" fill="#991b1b" font-size="10">recently_read を添付</text>
   <text x="540" y="200" fill="#ef4444" font-size="9">⚠ これは復元不可能な操作</text>
 
   <!-- 圧縮前/後 比較 -->

--- a/s08_context_compact/images/micro-compact.en.svg
+++ b/s08_context_compact/images/micro-compact.en.svg
@@ -16,7 +16,8 @@
   <!-- Pain Point -->
   <rect x="20" y="54" width="680" height="36" rx="6" fill="#fef2f2" stroke="#fca5a5" stroke-width="1"/>
   <text x="35" y="70" fill="#991b1b" font-size="11" font-weight="600">Pain Point</text>
-  <text x="110" y="70" fill="#991b1b" font-size="11">Agent read 10 files in a row; the full content of reads 1-7 is still sitting in context, taking space but no longer useful</text>
+  <text x="110" y="68" fill="#991b1b" font-size="10">After 10 reads, results 1-7 still sit in context.</text>
+  <text x="110" y="82" fill="#991b1b" font-size="10">They take space but are no longer useful.</text>
 
   <!-- Before -->
   <text x="155" y="114" fill="#64748b" font-size="12" font-weight="600" text-anchor="middle">Before (all 10 tool_result complete)</text>
@@ -45,7 +46,7 @@
   <text x="408" y="168" fill="#92400e" font-size="8" font-family="monospace">[Earlier result compacted. Re-run if needed.]</text>
   <rect x="400" y="175" width="290" height="10" rx="2" fill="#fef3c7"/>
   <text x="408" y="183" fill="#92400e" font-size="8" font-family="monospace">Read file J: (full content, 2800 chars)</text>
-  <text x="545" y="212" fill="#ca8a04" font-size="9" font-weight="600">Keep only latest 3; first 7 become placeholders</text>
+  <text x="545" y="212" fill="#ca8a04" font-size="9" font-weight="600" text-anchor="middle">Keep latest 3; first 7 become placeholders</text>
 
   <!-- How -->
   <rect x="20" y="228" width="680" height="62" rx="6" fill="#f8fafc" stroke="#cbd5e1" stroke-width="1"/>

--- a/s08_context_compact/images/micro-compact.ja.svg
+++ b/s08_context_compact/images/micro-compact.ja.svg
@@ -16,7 +16,8 @@
   <!-- ペインポイント -->
   <rect x="20" y="54" width="680" height="36" rx="6" fill="#fef2f2" stroke="#fca5a5" stroke-width="1"/>
   <text x="35" y="70" fill="#991b1b" font-size="11" font-weight="600">ペインポイント</text>
-  <text x="115" y="70" fill="#991b1b" font-size="11">Agent が連続で 10 ファイルを読み込み、1〜7 回目の完全なファイル内容がコンテキストに残ったまま、場所を占有しつつ既に不要</text>
+  <text x="115" y="68" fill="#991b1b" font-size="10">10 ファイルを読んでも、1〜7 回目の結果が残る。</text>
+  <text x="115" y="82" fill="#991b1b" font-size="10">古い内容が場所を取り続ける。</text>
 
   <!-- 圧縮前 -->
   <text x="155" y="114" fill="#64748b" font-size="12" font-weight="600" text-anchor="middle">圧縮前（10 件の tool_result がすべて完全）</text>
@@ -29,7 +30,7 @@
   <text x="38" y="168" fill="#94a3b8" font-size="8" font-family="monospace">Read file C: (完全な内容, 4500 文字)...</text>
   <rect x="30" y="175" width="290" height="10" rx="2" fill="#fef3c7"/>
   <text x="38" y="183" fill="#92400e" font-size="8" font-family="monospace">Read file J: (完全な内容, 2800 文字)</text>
-  <text x="175" y="212" fill="#ef4444" font-size="9" font-weight="600">7 件の旧結果が ~25K 文字を無駄に占有</text>
+  <text x="175" y="212" fill="#ef4444" font-size="9" font-weight="600" text-anchor="middle">7 件の旧結果が ~25K 文字を占有</text>
 
   <!-- 矢印 -->
   <line x1="335" y1="170" x2="375" y2="170" stroke="#ca8a04" stroke-width="2" marker-end="url(#arrow)"/>
@@ -45,7 +46,7 @@
   <text x="408" y="168" fill="#92400e" font-size="8" font-family="monospace">[Earlier result compacted. Re-run if needed.]</text>
   <rect x="400" y="175" width="290" height="10" rx="2" fill="#fef3c7"/>
   <text x="408" y="183" fill="#92400e" font-size="8" font-family="monospace">Read file J: (完全な内容, 2800 文字)</text>
-  <text x="545" y="212" fill="#ca8a04" font-size="9" font-weight="600">最新 3 件のみ保持、前 7 件はプレースホルダー化</text>
+  <text x="545" y="212" fill="#ca8a04" font-size="9" font-weight="600" text-anchor="middle">最新 3 件を保持、前 7 件は置換</text>
 
   <!-- 原理 -->
   <rect x="20" y="228" width="680" height="62" rx="6" fill="#f8fafc" stroke="#cbd5e1" stroke-width="1"/>

--- a/s09_memory/images/memory-subsystems.en.svg
+++ b/s09_memory/images/memory-subsystems.en.svg
@@ -36,17 +36,17 @@
   <rect x="457" y="58" width="130" height="80" rx="8" fill="#f3e8ff" stroke="#7c3aed" stroke-width="2"/>
   <text x="522" y="80" fill="#5b21b6" font-size="13" font-weight="700" text-anchor="middle">Extract</text>
   <line x1="472" y1="90" x2="572" y2="90" stroke="#c4b5fd" stroke-width="0.5"/>
-  <text x="472" y="108" fill="#5b21b6" font-size="10">After each turn ends</text>
-  <text x="472" y="124" fill="#5b21b6" font-size="10">LLM extracts prefs/constraints</text>
-  <text x="472" y="134" fill="#a78bfa" font-size="9">Check existing, avoid duplicates</text>
+  <text x="472" y="106" fill="#5b21b6" font-size="9.5">After each turn</text>
+  <text x="472" y="121" fill="#5b21b6" font-size="9.5">Extract prefs</text>
+  <text x="472" y="134" fill="#a78bfa" font-size="8.5">Avoid duplicates</text>
 
   <!-- Consolidation -->
   <rect x="600" y="58" width="100" height="80" rx="8" fill="#f5f3ff" stroke="#7c3aed" stroke-width="2"/>
-  <text x="650" y="80" fill="#5b21b6" font-size="13" font-weight="700" text-anchor="middle">Consolidate</text>
+  <text x="650" y="80" fill="#5b21b6" font-size="12" font-weight="700" text-anchor="middle">Consolidate</text>
   <line x1="615" y1="90" x2="685" y2="90" stroke="#c4b5fd" stroke-width="0.5"/>
-  <text x="615" y="108" fill="#5b21b6" font-size="10">Triggers at ≥ 10 files</text>
-  <text x="615" y="124" fill="#5b21b6" font-size="10">Dedup · merge · prune</text>
-  <text x="615" y="134" fill="#a78bfa" font-size="9">CC: 3-layer gating</text>
+  <text x="615" y="106" fill="#5b21b6" font-size="9.5">≥ 10 files</text>
+  <text x="615" y="121" fill="#5b21b6" font-size="9.5">Dedup · merge</text>
+  <text x="615" y="134" fill="#a78bfa" font-size="8.5">CC: gated Dream</text>
 
   <!-- Memory Files -->
   <rect x="40" y="180" width="660" height="36" rx="6" fill="#f8fafc" stroke="#94a3b8" stroke-width="1" stroke-dasharray="4,2"/>
@@ -74,5 +74,5 @@
   <text x="60" y="316" fill="#5b21b6" font-size="11" font-weight="600">CC Source Comparison</text>
   <text x="60" y="334" fill="#475569" font-size="10">• Selection: LLM side-query (Sonnet selects), not embedding vector similarity</text>
   <text x="60" y="350" fill="#475569" font-size="10">• Extraction timing: stop hook (after each turn ends), not after autoCompact</text>
-  <text x="60" y="366" fill="#475569" font-size="10">• Dream consolidation: 3-layer gating (time ≥ 24h + sessions ≥ 5 + file lock), not simple count</text>
+  <text x="60" y="365" fill="#475569" font-size="10">• Dream: time + sessions + file lock, not simple count</text>
 </svg>

--- a/s09_memory/images/memory-subsystems.ja.svg
+++ b/s09_memory/images/memory-subsystems.ja.svg
@@ -36,17 +36,17 @@
   <rect x="457" y="58" width="130" height="80" rx="8" fill="#f3e8ff" stroke="#7c3aed" stroke-width="2"/>
   <text x="522" y="80" fill="#5b21b6" font-size="13" font-weight="700" text-anchor="middle">抽出</text>
   <line x1="472" y1="90" x2="572" y2="90" stroke="#c4b5fd" stroke-width="0.5"/>
-  <text x="472" y="108" fill="#5b21b6" font-size="10">毎ターン終了後にトリガー</text>
-  <text x="472" y="124" fill="#5b21b6" font-size="10">LLM が好み/制約を抽出</text>
-  <text x="472" y="134" fill="#a78bfa" font-size="9">既存を確認、重複回避</text>
+  <text x="472" y="106" fill="#5b21b6" font-size="9.5">毎ターン終了後</text>
+  <text x="472" y="121" fill="#5b21b6" font-size="9.5">好み/制約を抽出</text>
+  <text x="472" y="134" fill="#a78bfa" font-size="8.5">重複を回避</text>
 
   <!-- 整理 -->
   <rect x="600" y="58" width="100" height="80" rx="8" fill="#f5f3ff" stroke="#7c3aed" stroke-width="2"/>
   <text x="650" y="80" fill="#5b21b6" font-size="13" font-weight="700" text-anchor="middle">整理</text>
   <line x1="615" y1="90" x2="685" y2="90" stroke="#c4b5fd" stroke-width="0.5"/>
-  <text x="615" y="108" fill="#5b21b6" font-size="10">ファイル ≥ 10 でトリガー</text>
-  <text x="615" y="124" fill="#5b21b6" font-size="10">重複排除・統合・剪定</text>
-  <text x="615" y="134" fill="#a78bfa" font-size="9">CC: 3 層ゲート</text>
+  <text x="615" y="106" fill="#5b21b6" font-size="9.5">≥ 10 ファイル</text>
+  <text x="615" y="121" fill="#5b21b6" font-size="9.5">重複排除・統合</text>
+  <text x="615" y="134" fill="#a78bfa" font-size="8.5">CC: Dream ゲート</text>
 
   <!-- Memory Files -->
   <rect x="40" y="180" width="660" height="36" rx="6" fill="#f8fafc" stroke="#94a3b8" stroke-width="1" stroke-dasharray="4,2"/>
@@ -74,5 +74,5 @@
   <text x="60" y="316" fill="#5b21b6" font-size="11" font-weight="600">CC ソースコード対照</text>
   <text x="60" y="334" fill="#475569" font-size="10">• 記憶選択：LLM side-query（Sonnet が選択）、embedding ベクトル類似度ではない</text>
   <text x="60" y="350" fill="#475569" font-size="10">• 抽出タイミング：stop hook（毎ターン終了後）、autoCompact 後ではない</text>
-  <text x="60" y="366" fill="#475569" font-size="10">• Dream 整理：3 層ゲート（時間 ≥ 24h + セッション ≥ 5 + ファイルロック）、単純な計数ではない</text>
+  <text x="60" y="365" fill="#475569" font-size="10">• Dream：時間・セッション・ロックで判定</text>
 </svg>

--- a/web/public/course-assets/s08_context_compact/auto-compact.en.svg
+++ b/web/public/course-assets/s08_context_compact/auto-compact.en.svg
@@ -22,10 +22,10 @@
   <!-- Steps -->
   <rect x="20" y="106" width="200" height="110" rx="8" fill="#fff" stroke="#94a3b8" stroke-width="1.5"/>
   <text x="120" y="130" fill="#1e3a5f" font-size="12" font-weight="700" text-anchor="middle">Step 1: Save transcript</text>
-  <text x="40" y="152" fill="#475569" font-size="10">Write full conversation to .transcripts/</text>
-  <text x="40" y="168" fill="#475569" font-size="10">JSONL format, one message per line</text>
-  <text x="40" y="184" fill="#475569" font-size="10">Filename: transcript_{timestamp}.jsonl</text>
-  <text x="40" y="200" fill="#94a3b8" font-size="9">No data lost, just moved out of active area</text>
+  <text x="40" y="152" fill="#475569" font-size="10">Write conversation to .transcripts/</text>
+  <text x="40" y="168" fill="#475569" font-size="10">One JSONL message per line</text>
+  <text x="40" y="184" fill="#475569" font-size="10">File: transcript_{time}.jsonl</text>
+  <text x="40" y="200" fill="#94a3b8" font-size="9">Full transcript stays on disk</text>
 
   <line x1="225" y1="161" x2="265" y2="161" stroke="#dc2626" stroke-width="2" marker-end="url(#arrow)"/>
 
@@ -33,9 +33,9 @@
   <text x="370" y="130" fill="#1e3a5f" font-size="12" font-weight="700" text-anchor="middle">Step 2: LLM generates summary</text>
   <text x="290" y="152" fill="#475569" font-size="10">Send conversation history to LLM</text>
   <text x="290" y="166" fill="#475569" font-size="9">Summary must include 9 sections:</text>
-  <text x="290" y="180" fill="#94a3b8" font-size="8">request · concepts · files · errors · resolutions</text>
-  <text x="290" y="192" fill="#94a3b8" font-size="8">user messages · todos · current state · next steps</text>
-  <text x="290" y="206" fill="#94a3b8" font-size="9">Generated only once</text>
+  <text x="370" y="180" fill="#94a3b8" font-size="8" text-anchor="middle">request · concepts · files · errors</text>
+  <text x="370" y="192" fill="#94a3b8" font-size="8" text-anchor="middle">resolutions · user messages · todos</text>
+  <text x="370" y="204" fill="#94a3b8" font-size="8" text-anchor="middle">current state · next steps</text>
 
   <line x1="475" y1="161" x2="515" y2="161" stroke="#dc2626" stroke-width="2" marker-end="url(#arrow)"/>
 

--- a/web/public/course-assets/s08_context_compact/auto-compact.ja.svg
+++ b/web/public/course-assets/s08_context_compact/auto-compact.ja.svg
@@ -24,8 +24,8 @@
   <text x="120" y="130" fill="#1e3a5f" font-size="12" font-weight="700" text-anchor="middle">ステップ 1：transcript 保存</text>
   <text x="40" y="152" fill="#475569" font-size="10">完全な対話を .transcripts/ に書き込み</text>
   <text x="40" y="168" fill="#475569" font-size="10">JSONL 形式、1 行 1 メッセージ</text>
-  <text x="40" y="184" fill="#475569" font-size="10">ファイル名：transcript_{timestamp}.jsonl</text>
-  <text x="40" y="200" fill="#94a3b8" font-size="9">情報は失われていない、アクティブ領域から移動のみ</text>
+  <text x="40" y="184" fill="#475569" font-size="10">transcript_{time}.jsonl</text>
+  <text x="40" y="200" fill="#94a3b8" font-size="9">内容はディスクに残る</text>
 
   <line x1="225" y1="161" x2="265" y2="161" stroke="#dc2626" stroke-width="2" marker-end="url(#arrow)"/>
 
@@ -40,10 +40,10 @@
   <line x1="475" y1="161" x2="515" y2="161" stroke="#dc2626" stroke-width="2" marker-end="url(#arrow)"/>
 
   <rect x="520" y="106" width="180" height="110" rx="8" fill="#fef2f2" stroke="#dc2626" stroke-width="2"/>
-  <text x="610" y="130" fill="#991b1b" font-size="12" font-weight="700" text-anchor="middle">ステップ 3：メッセージリスト置換</text>
+  <text x="610" y="130" fill="#991b1b" font-size="12" font-weight="700" text-anchor="middle">ステップ 3：要約に置換</text>
   <text x="540" y="152" fill="#991b1b" font-size="10">全旧メッセージ → 1 件の要約に</text>
   <text x="540" y="168" fill="#991b1b" font-size="10">モデルは要約から作業を継続</text>
-  <text x="540" y="184" fill="#991b1b" font-size="10">recently_read ファイルリストを付与</text>
+  <text x="540" y="184" fill="#991b1b" font-size="10">recently_read を添付</text>
   <text x="540" y="200" fill="#ef4444" font-size="9">⚠ これは復元不可能な操作</text>
 
   <!-- 圧縮前/後 比較 -->

--- a/web/public/course-assets/s08_context_compact/micro-compact.en.svg
+++ b/web/public/course-assets/s08_context_compact/micro-compact.en.svg
@@ -16,7 +16,8 @@
   <!-- Pain Point -->
   <rect x="20" y="54" width="680" height="36" rx="6" fill="#fef2f2" stroke="#fca5a5" stroke-width="1"/>
   <text x="35" y="70" fill="#991b1b" font-size="11" font-weight="600">Pain Point</text>
-  <text x="110" y="70" fill="#991b1b" font-size="11">Agent read 10 files in a row; the full content of reads 1-7 is still sitting in context, taking space but no longer useful</text>
+  <text x="110" y="68" fill="#991b1b" font-size="10">After 10 reads, results 1-7 still sit in context.</text>
+  <text x="110" y="82" fill="#991b1b" font-size="10">They take space but are no longer useful.</text>
 
   <!-- Before -->
   <text x="155" y="114" fill="#64748b" font-size="12" font-weight="600" text-anchor="middle">Before (all 10 tool_result complete)</text>
@@ -45,7 +46,7 @@
   <text x="408" y="168" fill="#92400e" font-size="8" font-family="monospace">[Earlier result compacted. Re-run if needed.]</text>
   <rect x="400" y="175" width="290" height="10" rx="2" fill="#fef3c7"/>
   <text x="408" y="183" fill="#92400e" font-size="8" font-family="monospace">Read file J: (full content, 2800 chars)</text>
-  <text x="545" y="212" fill="#ca8a04" font-size="9" font-weight="600">Keep only latest 3; first 7 become placeholders</text>
+  <text x="545" y="212" fill="#ca8a04" font-size="9" font-weight="600" text-anchor="middle">Keep latest 3; first 7 become placeholders</text>
 
   <!-- How -->
   <rect x="20" y="228" width="680" height="62" rx="6" fill="#f8fafc" stroke="#cbd5e1" stroke-width="1"/>

--- a/web/public/course-assets/s08_context_compact/micro-compact.ja.svg
+++ b/web/public/course-assets/s08_context_compact/micro-compact.ja.svg
@@ -16,7 +16,8 @@
   <!-- ペインポイント -->
   <rect x="20" y="54" width="680" height="36" rx="6" fill="#fef2f2" stroke="#fca5a5" stroke-width="1"/>
   <text x="35" y="70" fill="#991b1b" font-size="11" font-weight="600">ペインポイント</text>
-  <text x="115" y="70" fill="#991b1b" font-size="11">Agent が連続で 10 ファイルを読み込み、1〜7 回目の完全なファイル内容がコンテキストに残ったまま、場所を占有しつつ既に不要</text>
+  <text x="115" y="68" fill="#991b1b" font-size="10">10 ファイルを読んでも、1〜7 回目の結果が残る。</text>
+  <text x="115" y="82" fill="#991b1b" font-size="10">古い内容が場所を取り続ける。</text>
 
   <!-- 圧縮前 -->
   <text x="155" y="114" fill="#64748b" font-size="12" font-weight="600" text-anchor="middle">圧縮前（10 件の tool_result がすべて完全）</text>
@@ -29,7 +30,7 @@
   <text x="38" y="168" fill="#94a3b8" font-size="8" font-family="monospace">Read file C: (完全な内容, 4500 文字)...</text>
   <rect x="30" y="175" width="290" height="10" rx="2" fill="#fef3c7"/>
   <text x="38" y="183" fill="#92400e" font-size="8" font-family="monospace">Read file J: (完全な内容, 2800 文字)</text>
-  <text x="175" y="212" fill="#ef4444" font-size="9" font-weight="600">7 件の旧結果が ~25K 文字を無駄に占有</text>
+  <text x="175" y="212" fill="#ef4444" font-size="9" font-weight="600" text-anchor="middle">7 件の旧結果が ~25K 文字を占有</text>
 
   <!-- 矢印 -->
   <line x1="335" y1="170" x2="375" y2="170" stroke="#ca8a04" stroke-width="2" marker-end="url(#arrow)"/>
@@ -45,7 +46,7 @@
   <text x="408" y="168" fill="#92400e" font-size="8" font-family="monospace">[Earlier result compacted. Re-run if needed.]</text>
   <rect x="400" y="175" width="290" height="10" rx="2" fill="#fef3c7"/>
   <text x="408" y="183" fill="#92400e" font-size="8" font-family="monospace">Read file J: (完全な内容, 2800 文字)</text>
-  <text x="545" y="212" fill="#ca8a04" font-size="9" font-weight="600">最新 3 件のみ保持、前 7 件はプレースホルダー化</text>
+  <text x="545" y="212" fill="#ca8a04" font-size="9" font-weight="600" text-anchor="middle">最新 3 件を保持、前 7 件は置換</text>
 
   <!-- 原理 -->
   <rect x="20" y="228" width="680" height="62" rx="6" fill="#f8fafc" stroke="#cbd5e1" stroke-width="1"/>

--- a/web/public/course-assets/s09_memory/memory-subsystems.en.svg
+++ b/web/public/course-assets/s09_memory/memory-subsystems.en.svg
@@ -36,17 +36,17 @@
   <rect x="457" y="58" width="130" height="80" rx="8" fill="#f3e8ff" stroke="#7c3aed" stroke-width="2"/>
   <text x="522" y="80" fill="#5b21b6" font-size="13" font-weight="700" text-anchor="middle">Extract</text>
   <line x1="472" y1="90" x2="572" y2="90" stroke="#c4b5fd" stroke-width="0.5"/>
-  <text x="472" y="108" fill="#5b21b6" font-size="10">After each turn ends</text>
-  <text x="472" y="124" fill="#5b21b6" font-size="10">LLM extracts prefs/constraints</text>
-  <text x="472" y="134" fill="#a78bfa" font-size="9">Check existing, avoid duplicates</text>
+  <text x="472" y="106" fill="#5b21b6" font-size="9.5">After each turn</text>
+  <text x="472" y="121" fill="#5b21b6" font-size="9.5">Extract prefs</text>
+  <text x="472" y="134" fill="#a78bfa" font-size="8.5">Avoid duplicates</text>
 
   <!-- Consolidation -->
   <rect x="600" y="58" width="100" height="80" rx="8" fill="#f5f3ff" stroke="#7c3aed" stroke-width="2"/>
-  <text x="650" y="80" fill="#5b21b6" font-size="13" font-weight="700" text-anchor="middle">Consolidate</text>
+  <text x="650" y="80" fill="#5b21b6" font-size="12" font-weight="700" text-anchor="middle">Consolidate</text>
   <line x1="615" y1="90" x2="685" y2="90" stroke="#c4b5fd" stroke-width="0.5"/>
-  <text x="615" y="108" fill="#5b21b6" font-size="10">Triggers at ≥ 10 files</text>
-  <text x="615" y="124" fill="#5b21b6" font-size="10">Dedup · merge · prune</text>
-  <text x="615" y="134" fill="#a78bfa" font-size="9">CC: 3-layer gating</text>
+  <text x="615" y="106" fill="#5b21b6" font-size="9.5">≥ 10 files</text>
+  <text x="615" y="121" fill="#5b21b6" font-size="9.5">Dedup · merge</text>
+  <text x="615" y="134" fill="#a78bfa" font-size="8.5">CC: gated Dream</text>
 
   <!-- Memory Files -->
   <rect x="40" y="180" width="660" height="36" rx="6" fill="#f8fafc" stroke="#94a3b8" stroke-width="1" stroke-dasharray="4,2"/>
@@ -74,5 +74,5 @@
   <text x="60" y="316" fill="#5b21b6" font-size="11" font-weight="600">CC Source Comparison</text>
   <text x="60" y="334" fill="#475569" font-size="10">• Selection: LLM side-query (Sonnet selects), not embedding vector similarity</text>
   <text x="60" y="350" fill="#475569" font-size="10">• Extraction timing: stop hook (after each turn ends), not after autoCompact</text>
-  <text x="60" y="366" fill="#475569" font-size="10">• Dream consolidation: 3-layer gating (time ≥ 24h + sessions ≥ 5 + file lock), not simple count</text>
+  <text x="60" y="365" fill="#475569" font-size="10">• Dream: time + sessions + file lock, not simple count</text>
 </svg>

--- a/web/public/course-assets/s09_memory/memory-subsystems.ja.svg
+++ b/web/public/course-assets/s09_memory/memory-subsystems.ja.svg
@@ -36,17 +36,17 @@
   <rect x="457" y="58" width="130" height="80" rx="8" fill="#f3e8ff" stroke="#7c3aed" stroke-width="2"/>
   <text x="522" y="80" fill="#5b21b6" font-size="13" font-weight="700" text-anchor="middle">抽出</text>
   <line x1="472" y1="90" x2="572" y2="90" stroke="#c4b5fd" stroke-width="0.5"/>
-  <text x="472" y="108" fill="#5b21b6" font-size="10">毎ターン終了後にトリガー</text>
-  <text x="472" y="124" fill="#5b21b6" font-size="10">LLM が好み/制約を抽出</text>
-  <text x="472" y="134" fill="#a78bfa" font-size="9">既存を確認、重複回避</text>
+  <text x="472" y="106" fill="#5b21b6" font-size="9.5">毎ターン終了後</text>
+  <text x="472" y="121" fill="#5b21b6" font-size="9.5">好み/制約を抽出</text>
+  <text x="472" y="134" fill="#a78bfa" font-size="8.5">重複を回避</text>
 
   <!-- 整理 -->
   <rect x="600" y="58" width="100" height="80" rx="8" fill="#f5f3ff" stroke="#7c3aed" stroke-width="2"/>
   <text x="650" y="80" fill="#5b21b6" font-size="13" font-weight="700" text-anchor="middle">整理</text>
   <line x1="615" y1="90" x2="685" y2="90" stroke="#c4b5fd" stroke-width="0.5"/>
-  <text x="615" y="108" fill="#5b21b6" font-size="10">ファイル ≥ 10 でトリガー</text>
-  <text x="615" y="124" fill="#5b21b6" font-size="10">重複排除・統合・剪定</text>
-  <text x="615" y="134" fill="#a78bfa" font-size="9">CC: 3 層ゲート</text>
+  <text x="615" y="106" fill="#5b21b6" font-size="9.5">≥ 10 ファイル</text>
+  <text x="615" y="121" fill="#5b21b6" font-size="9.5">重複排除・統合</text>
+  <text x="615" y="134" fill="#a78bfa" font-size="8.5">CC: Dream ゲート</text>
 
   <!-- Memory Files -->
   <rect x="40" y="180" width="660" height="36" rx="6" fill="#f8fafc" stroke="#94a3b8" stroke-width="1" stroke-dasharray="4,2"/>
@@ -74,5 +74,5 @@
   <text x="60" y="316" fill="#5b21b6" font-size="11" font-weight="600">CC ソースコード対照</text>
   <text x="60" y="334" fill="#475569" font-size="10">• 記憶選択：LLM side-query（Sonnet が選択）、embedding ベクトル類似度ではない</text>
   <text x="60" y="350" fill="#475569" font-size="10">• 抽出タイミング：stop hook（毎ターン終了後）、autoCompact 後ではない</text>
-  <text x="60" y="366" fill="#475569" font-size="10">• Dream 整理：3 層ゲート（時間 ≥ 24h + セッション ≥ 5 + ファイルロック）、単純な計数ではない</text>
+  <text x="60" y="365" fill="#475569" font-size="10">• Dream：時間・セッション・ロックで判定</text>
 </svg>


### PR DESCRIPTION
## Summary
- shorten and reflow s08 context compact SVG labels for English and Japanese assets
- update s09 memory subsystem SVG labels in source images and generated course assets
- keep source image files and web/public course-assets in sync so extraction does not regress the fix

## Verification
- npm run build
- Chromium getBBox overflow check for s08 micro/auto compact SVGs and s09 memory subsystem SVGs