### PR TITLE
fix(s03): route permission-overview deny arrow back to messages[]

### DIFF
--- a/s03_permission/images/permission-overview.en.svg
+++ b/s03_permission/images/permission-overview.en.svg
@@ -68,9 +68,9 @@
   <rect x="416" y="170" width="132" height="24" rx="4" fill="#fef3c7" stroke="#d97706" stroke-width="1"/>
   <text x="482" y="186" fill="#92400e" font-size="9" font-weight="600" text-anchor="middle">Gate 3: User Approval</text>
 
-  <!-- Deny → return deny message -->
-  <path d="M 402 188 L 376 188 L 376 174 L 350 174" fill="none" stroke="#dc2626" stroke-width="1.5" marker-end="url(#arrow-red)"/>
-  <text x="378" y="184" fill="#dc2626" font-size="8" font-weight="600">Deny</text>
+  <!-- Deny: denial becomes a tool_result that flows back to messages[] (joins the pass path) -->
+  <path d="M 440 198 L 440 230" fill="none" stroke="#dc2626" stroke-width="1.5" marker-end="url(#arrow-red)"/>
+  <text x="446" y="218" fill="#dc2626" font-size="8" font-weight="600">Deny</text>
 
   <!-- Pass → tool execution -->
   <line x1="562" y1="138" x2="598" y2="138" stroke="#555" stroke-width="1.5" marker-end="url(#arrow)"/>

--- a/s03_permission/images/permission-overview.en.svg
+++ b/s03_permission/images/permission-overview.en.svg
@@ -68,9 +68,9 @@
   <rect x="416" y="170" width="132" height="24" rx="4" fill="#fef3c7" stroke="#d97706" stroke-width="1"/>
   <text x="482" y="186" fill="#92400e" font-size="9" font-weight="600" text-anchor="middle">Gate 3: User Approval</text>
 
-  <!-- Deny: denial becomes a tool_result that flows back to messages[] (joins the pass path) -->
-  <path d="M 440 198 L 440 230" fill="none" stroke="#dc2626" stroke-width="1.5" marker-end="url(#arrow-red)"/>
-  <text x="446" y="218" fill="#dc2626" font-size="8" font-weight="600">Deny</text>
+  <!-- Deny: denial becomes a tool_result, converging with the pass output -->
+  <path d="M 440 198 L 440 216" fill="none" stroke="#dc2626" stroke-width="1.5" marker-end="url(#arrow-red)"/>
+  <text x="446" y="210" fill="#dc2626" font-size="8" font-weight="600">Deny</text>
 
   <!-- Pass → tool execution -->
   <line x1="562" y1="138" x2="598" y2="138" stroke="#555" stroke-width="1.5" marker-end="url(#arrow)"/>
@@ -85,8 +85,15 @@
   <text x="650" y="166" fill="#1e3a5f" font-size="10" font-weight="600" text-anchor="middle">HANDLERS</text>
   <text x="650" y="184" fill="#64748b" font-size="8" text-anchor="middle">bash/read/write/...</text>
 
-  <!-- Arrow: tool results → back to messages -->
-  <path d="M 700 162 L 710 162 L 710 230 L 120 230 L 120 128" fill="none" stroke="#555" stroke-width="1.5" marker-end="url(#arrow)" stroke-dasharray="6,3"/>
+  <!-- Pass output: TOOL_HANDLERS result → tool_result -->
+  <path d="M 650 194 L 650 230 L 492 230" fill="none" stroke="#555" stroke-width="1.5" marker-end="url(#arrow)" stroke-dasharray="6,3"/>
+
+  <!-- tool_result: both a successful output and a denial become a tool_result -->
+  <rect x="370" y="216" width="122" height="28" rx="6" fill="#f0f4ff" stroke="#2563eb" stroke-width="1.5"/>
+  <text x="431" y="234" fill="#1e3a5f" font-size="11" font-weight="600" text-anchor="middle">tool_result</text>
+
+  <!-- tool_result → back to messages[] -->
+  <path d="M 370 230 L 120 230 L 120 128" fill="none" stroke="#555" stroke-width="1.5" marker-end="url(#arrow)" stroke-dasharray="6,3"/>
 
   <!-- ===== Legend ===== -->
   <rect x="60" y="260" width="600" height="44" rx="6" fill="#f1f5f9"/>

--- a/s03_permission/images/permission-overview.ja.svg
+++ b/s03_permission/images/permission-overview.ja.svg
@@ -68,9 +68,9 @@
   <rect x="416" y="170" width="132" height="24" rx="4" fill="#fef3c7" stroke="#d97706" stroke-width="1"/>
   <text x="482" y="186" fill="#92400e" font-size="9" font-weight="600" text-anchor="middle">ゲート 3: ユーザー承認</text>
 
-  <!-- 拒否 → 拒否メッセージは tool_result として messages[] に戻る（通過パスと合流） -->
-  <path d="M 440 198 L 440 230" fill="none" stroke="#dc2626" stroke-width="1.5" marker-end="url(#arrow-red)"/>
-  <text x="446" y="218" fill="#dc2626" font-size="8" font-weight="600">拒否</text>
+  <!-- 拒否：拒否は tool_result となり、通過パスの出力と合流する -->
+  <path d="M 440 198 L 440 216" fill="none" stroke="#dc2626" stroke-width="1.5" marker-end="url(#arrow-red)"/>
+  <text x="446" y="210" fill="#dc2626" font-size="8" font-weight="600">拒否</text>
 
   <!-- 通過 → ツール実行 -->
   <line x1="562" y1="138" x2="598" y2="138" stroke="#555" stroke-width="1.5" marker-end="url(#arrow)"/>
@@ -85,8 +85,15 @@
   <text x="650" y="166" fill="#1e3a5f" font-size="10" font-weight="600" text-anchor="middle">HANDLERS</text>
   <text x="650" y="184" fill="#64748b" font-size="8" text-anchor="middle">bash/read/write/...</text>
 
-  <!-- 矢印：ツール結果 → メッセージリストに戻る -->
-  <path d="M 700 162 L 710 162 L 710 230 L 120 230 L 120 128" fill="none" stroke="#555" stroke-width="1.5" marker-end="url(#arrow)" stroke-dasharray="6,3"/>
+  <!-- 通過の出力：TOOL_HANDLERS の結果 → tool_result -->
+  <path d="M 650 194 L 650 230 L 492 230" fill="none" stroke="#555" stroke-width="1.5" marker-end="url(#arrow)" stroke-dasharray="6,3"/>
+
+  <!-- tool_result：成功した出力も拒否も tool_result になる -->
+  <rect x="370" y="216" width="122" height="28" rx="6" fill="#f0f4ff" stroke="#2563eb" stroke-width="1.5"/>
+  <text x="431" y="234" fill="#1e3a5f" font-size="11" font-weight="600" text-anchor="middle">tool_result</text>
+
+  <!-- tool_result → メッセージリストに戻る -->
+  <path d="M 370 230 L 120 230 L 120 128" fill="none" stroke="#555" stroke-width="1.5" marker-end="url(#arrow)" stroke-dasharray="6,3"/>
 
   <!-- ===== 凡例 ===== -->
   <rect x="60" y="260" width="600" height="44" rx="6" fill="#f1f5f9"/>

--- a/s03_permission/images/permission-overview.ja.svg
+++ b/s03_permission/images/permission-overview.ja.svg
@@ -68,9 +68,9 @@
   <rect x="416" y="170" width="132" height="24" rx="4" fill="#fef3c7" stroke="#d97706" stroke-width="1"/>
   <text x="482" y="186" fill="#92400e" font-size="9" font-weight="600" text-anchor="middle">ゲート 3: ユーザー承認</text>
 
-  <!-- 拒否 → 拒否メッセージを返す -->
-  <path d="M 402 188 L 376 188 L 376 174 L 350 174" fill="none" stroke="#dc2626" stroke-width="1.5" marker-end="url(#arrow-red)"/>
-  <text x="378" y="184" fill="#dc2626" font-size="8" font-weight="600">拒否</text>
+  <!-- 拒否 → 拒否メッセージは tool_result として messages[] に戻る（通過パスと合流） -->
+  <path d="M 440 198 L 440 230" fill="none" stroke="#dc2626" stroke-width="1.5" marker-end="url(#arrow-red)"/>
+  <text x="446" y="218" fill="#dc2626" font-size="8" font-weight="600">拒否</text>
 
   <!-- 通過 → ツール実行 -->
   <line x1="562" y1="138" x2="598" y2="138" stroke="#555" stroke-width="1.5" marker-end="url(#arrow)"/>

--- a/s03_permission/images/permission-overview.svg
+++ b/s03_permission/images/permission-overview.svg
@@ -68,9 +68,9 @@
   <rect x="416" y="170" width="132" height="24" rx="4" fill="#fef3c7" stroke="#d97706" stroke-width="1"/>
   <text x="482" y="186" fill="#92400e" font-size="9" font-weight="600" text-anchor="middle">闸门 3: 用户审批</text>
 
-  <!-- 拒绝 → 返回拒绝信息 -->
-  <path d="M 402 188 L 376 188 L 376 174 L 350 174" fill="none" stroke="#dc2626" stroke-width="1.5" marker-end="url(#arrow-red)"/>
-  <text x="378" y="184" fill="#dc2626" font-size="8" font-weight="600">拒绝</text>
+  <!-- 拒绝 → 拒绝信息作为 tool_result 回到 messages[]（与通过路径汇合） -->
+  <path d="M 440 198 L 440 230" fill="none" stroke="#dc2626" stroke-width="1.5" marker-end="url(#arrow-red)"/>
+  <text x="446" y="218" fill="#dc2626" font-size="8" font-weight="600">拒绝</text>
 
   <!-- 通过 → 工具执行 -->
   <line x1="562" y1="138" x2="598" y2="138" stroke="#555" stroke-width="1.5" marker-end="url(#arrow)"/>

--- a/s03_permission/images/permission-overview.svg
+++ b/s03_permission/images/permission-overview.svg
@@ -68,9 +68,9 @@
   <rect x="416" y="170" width="132" height="24" rx="4" fill="#fef3c7" stroke="#d97706" stroke-width="1"/>
   <text x="482" y="186" fill="#92400e" font-size="9" font-weight="600" text-anchor="middle">闸门 3: 用户审批</text>
 
-  <!-- 拒绝 → 拒绝信息作为 tool_result 回到 messages[]（与通过路径汇合） -->
-  <path d="M 440 198 L 440 230" fill="none" stroke="#dc2626" stroke-width="1.5" marker-end="url(#arrow-red)"/>
-  <text x="446" y="218" fill="#dc2626" font-size="8" font-weight="600">拒绝</text>
+  <!-- 拒绝：拒绝信息成为 tool_result，与通过路径的输出汇合 -->
+  <path d="M 440 198 L 440 216" fill="none" stroke="#dc2626" stroke-width="1.5" marker-end="url(#arrow-red)"/>
+  <text x="446" y="210" fill="#dc2626" font-size="8" font-weight="600">拒绝</text>
 
   <!-- 通过 → 工具执行 -->
   <line x1="562" y1="138" x2="598" y2="138" stroke="#555" stroke-width="1.5" marker-end="url(#arrow)"/>
@@ -85,8 +85,15 @@
   <text x="650" y="166" fill="#1e3a5f" font-size="10" font-weight="600" text-anchor="middle">HANDLERS</text>
   <text x="650" y="184" fill="#64748b" font-size="8" text-anchor="middle">bash/read/write/...</text>
 
-  <!-- 箭头：工具结果 → 回到消息列表 -->
-  <path d="M 700 162 L 710 162 L 710 230 L 120 230 L 120 128" fill="none" stroke="#555" stroke-width="1.5" marker-end="url(#arrow)" stroke-dasharray="6,3"/>
+  <!-- 通过路径的输出：TOOL_HANDLERS 结果 → tool_result -->
+  <path d="M 650 194 L 650 230 L 492 230" fill="none" stroke="#555" stroke-width="1.5" marker-end="url(#arrow)" stroke-dasharray="6,3"/>
+
+  <!-- tool_result：成功的输出和拒绝都会成为 tool_result -->
+  <rect x="370" y="216" width="122" height="28" rx="6" fill="#f0f4ff" stroke="#2563eb" stroke-width="1.5"/>
+  <text x="431" y="234" fill="#1e3a5f" font-size="11" font-weight="600" text-anchor="middle">tool_result</text>
+
+  <!-- tool_result → 回到消息列表 -->
+  <path d="M 370 230 L 120 230 L 120 128" fill="none" stroke="#555" stroke-width="1.5" marker-end="url(#arrow)" stroke-dasharray="6,3"/>
 
   <!-- ===== 图例 ===== -->
   <rect x="60" y="260" width="600" height="44" rx="6" fill="#f1f5f9"/>


### PR DESCRIPTION
## Summary

The permission-overview diagram drew the `Deny` branch of `check_permission()` as an arrow into the green "Return result" node. That node is the loop's exit (the `stop_reason != "tool_use"` / No branch), so the diagram implied a permission denial terminates the agent loop and returns to the user.

The code does the opposite: a denied tool appends a `"Permission denied."` tool_result and calls `continue`, so the denial flows back to `messages[]` and the loop keeps going (`s03_permission/code.py`, `agent_loop`). The only loop exit is `stop_reason != "tool_use"`.

This reroutes the `Deny` arrow so it drops into the existing "tool results back to messages[]" return lane instead of pointing at the terminal node, across all three language variants (zh, en, ja).

Fixes #316.

## Notes

Geometry-only change to the three permission-overview SVGs. No code or text content changed besides the deny arrow's path, its label position, and the source comment.