### PR TITLE
fix(s04): align problem code block with early-continue idiom

### DIFF
--- a/s04_hooks/README.en.md
+++ b/s04_hooks/README.en.md
@@ -21,13 +21,14 @@ def agent_loop(messages):
     while True:
         # ... LLM call ...
         for block in response.content:
-            if block.type == "tool_use":
-                log_to_file(block)          # added a line
-                check_permission(block)     # added a line
-                notify_slack(block)         # added another line
-                output = execute(block)
-                auto_git_add(block)         # yet another line
-                # ... the loop is unrecognizable
+            if block.type != "tool_use":
+                continue
+            log_to_file(block)          # added a line
+            check_permission(block)     # added a line
+            notify_slack(block)         # added another line
+            output = execute(block)
+            auto_git_add(block)         # yet another line
+            # ... the loop is unrecognizable
 ```
 
 What you want to extend is the Agent's behavior, but what you're modifying is the loop itself. The loop should be a stable core; extensions should hang on the outside.

--- a/s04_hooks/README.ja.md
+++ b/s04_hooks/README.ja.md
@@ -21,13 +21,14 @@ def agent_loop(messages):
     while True:
         # ... LLM call ...
         for block in response.content:
-            if block.type == "tool_use":
-                log_to_file(block)          # 一行追加
-                check_permission(block)     # 一行追加
-                notify_slack(block)         # さらに一行追加
-                output = execute(block)
-                auto_git_add(block)         # さらに一行追加
-                # ... もうループが見えない
+            if block.type != "tool_use":
+                continue
+            log_to_file(block)          # 一行追加
+            check_permission(block)     # 一行追加
+            notify_slack(block)         # さらに一行追加
+            output = execute(block)
+            auto_git_add(block)         # さらに一行追加
+            # ... もうループが見えない
 ```
 
 拡張したいのは Agent の振る舞いなのに、変更しているのはループそのもの。ループは安定した核心であるべき。拡張は外側に掛ける。

--- a/s04_hooks/README.md
+++ b/s04_hooks/README.md
@@ -21,13 +21,14 @@ def agent_loop(messages):
     while True:
         # ... LLM call ...
         for block in response.content:
-            if block.type == "tool_use":
-                log_to_file(block)          # 加一行
-                check_permission(block)     # 加一行
-                notify_slack(block)         # 又加一行
-                output = execute(block)
-                auto_git_add(block)         # 再加一行
-                # ... 很快循环就认不出来了
+            if block.type != "tool_use":
+                continue
+            log_to_file(block)          # 加一行
+            check_permission(block)     # 加一行
+            notify_slack(block)         # 又加一行
+            output = execute(block)
+            auto_git_add(block)         # 再加一行
+            # ... 很快循环就认不出来了
 ```
 
 你想扩展的是 Agent 的行为，但你改的却是循环本身。循环应该是一个稳定的核心，扩展应该挂在外面。


### PR DESCRIPTION
Fixes #319.

## Problem

In `s04_hooks/README.md`, the problem block (lines 19-31) used a nested `if block.type == "tool_use":`, while the solution block (lines 160-180) and `s04_hooks/code.py` use the early-continue guard `if block.type != "tool_use": continue`.

The README states that only one place in the loop changed ("循环里只改了一处"), but diffing the two blocks showed two changes: the incidental nested-`if` -> early-`continue` restructuring, plus the intended `check_permission(block)` -> `trigger_hooks("PreToolUse", block)` substitution. The restructuring distracted from the single change the section teaches.

## Fix

Convert the problem block in all three README variants (zh / en / ja) to the early-continue idiom so the only visible diff between problem and solution is the hook substitution.

## Test plan

- [x] `README.md`, `README.en.md`, `README.ja.md` problem blocks now match the solution block and `code.py` idiom
- [x] Comments preserved in each language