### PR TITLE
fix(s06): move extract_text() next to its only caller

### DIFF
--- a/s06_subagent/code.py
+++ b/s06_subagent/code.py
@@ -136,12 +136,6 @@ def run_todo_write(todos: list) -> str:
     print("\n".join(lines))
     return f"Updated {len(CURRENT_TODOS)} tasks"
 
-def extract_text(content) -> str:
-    """Extract text from message content blocks."""
-    if not isinstance(content, list):
-        return str(content)
-    return "\n".join(getattr(b, "text", "") for b in content if getattr(b, "type", None) == "text")
-
 TOOLS = [
     {"name": "bash", "description": "Run a shell command.",
      "input_schema": {"type": "object", "properties": {"command": {"type": "string"}}, "required": ["command"]}},
@@ -185,6 +179,12 @@ SUB_HANDLERS = {
     "bash": run_bash, "read_file": run_read, "write_file": run_write,
     "edit_file": run_edit, "glob": run_glob,
 }
+
+def extract_text(content) -> str:
+    """Extract text from message content blocks."""
+    if not isinstance(content, list):
+        return str(content)
+    return "\n".join(getattr(b, "text", "") for b in content if getattr(b, "type", None) == "text")
 
 def spawn_subagent(description: str) -> str:
     """Spawn a subagent with fresh messages[], return summary only."""


### PR DESCRIPTION
## Summary

`extract_text()` in `s06_subagent/code.py` is **new in s06** (the module docstring lists it under "Changes from s05": `+ extract_text() helper`), but it was defined under the `FROM s02-s05 (unchanged): Tool Implementations` banner. That contradicts the tutorial's section-by-section structure and misleads learners.

This PR moves `extract_text()` into the `NEW in s06: Subagent` section, directly above its only caller `spawn_subagent()`. Pure move, no logic change.

Fixes #321

## Test plan

- [x] `python3 -m py_compile s06_subagent/code.py` passes
- [x] Diff is a clean move (6 insertions / 6 deletions, no logic change)
- [x] `extract_text()` now sits directly above `spawn_subagent()`, its only caller