### PR TITLE
fix 400 error in s13_background_tasks

### DIFF
--- a/s13_background_tasks/code.py
+++ b/s13_background_tasks/code.py
@@ -444,15 +444,14 @@ def agent_loop(messages: list, context: dict):
                                 "tool_use_id": block.id,
                                 "content": output})
 
-        # Inject background notifications + tool results in one user message
-        user_content = []
+        # Inject tool results + background notifications in one user message
+        user_content = list(results)
         bg_notifications = collect_background_results()
         if bg_notifications:
             for notif in bg_notifications:
                 user_content.append({"type": "text", "text": notif})
             print(f"  \033[32m[inject] {len(bg_notifications)} background "
                   f"notification(s)\033[0m")
-        user_content.extend(results)
         messages.append({"role": "user", "content": user_content})
         context = update_context(context, messages)
         system = get_system_prompt(context)

--- a/s14_cron_scheduler/code.py
+++ b/s14_cron_scheduler/code.py
@@ -726,13 +726,12 @@ def agent_loop(messages: list, context: dict) -> dict:
                                 "tool_use_id": block.id,
                                 "content": output})
 
-        # Merge background notifications + tool results into one user message
-        user_content = []
+        # Merge background tool results + notifications into one user message
+        user_content = list(results)
         bg_notifications = collect_background_results()
         if bg_notifications:
             for notif in bg_notifications:
                 user_content.append({"type": "text", "text": notif})
-        user_content.extend(results)
         messages.append({"role": "user", "content": user_content})
         context = update_context(context, messages)
         system = get_system_prompt(context)

--- a/s15_agent_teams/code.py
+++ b/s15_agent_teams/code.py
@@ -887,13 +887,12 @@ def agent_loop(messages: list, context: dict):
                                 "tool_use_id": block.id,
                                 "content": output})
 
-        # Merge background notifications + tool results into one user message
-        user_content = []
+        # Merge background tool results + notifications into one user message
+        user_content = list(results)
         bg_notifications = collect_background_results()
         if bg_notifications:
             for notif in bg_notifications:
                 user_content.append({"type": "text", "text": notif})
-        user_content.extend(results)
         messages.append({"role": "user", "content": user_content})
         context = update_context(context, messages)
         system = get_system_prompt(context)

--- a/s16_team_protocols/code.py
+++ b/s16_team_protocols/code.py
@@ -839,13 +839,12 @@ def agent_loop(messages: list, context: dict):
                                 "tool_use_id": block.id,
                                 "content": output})
 
-        # Merge background notifications + tool results into one user message
-        user_content = []
+        # Merge background tool results + notifications into one user message
+        user_content = list(results)
         bg_notifications = collect_background_results()
         if bg_notifications:
             for notif in bg_notifications:
                 user_content.append({"type": "text", "text": notif})
-        user_content.extend(results)
         messages.append({"role": "user", "content": user_content})
         context = update_context(context, messages)
         system = get_system_prompt(context)

--- a/s20_comprehensive/code.py
+++ b/s20_comprehensive/code.py
@@ -1872,10 +1872,9 @@ def prepare_context(messages: list) -> list:
 def build_user_content(results: list[dict]) -> list[dict]:
     # Tool results and completed background notifications are both returned to
     # the model as user-side content, matching the tool_result feedback loop.
-    content = []
+    content = list(results)
     for note in collect_background_results():
         content.append({"type": "text", "text": note})
-    content.extend(results)
     return content
 
 


### PR DESCRIPTION
# fix(s13): 修复 user 消息中 tool_result 必须在 text 之前的排序 bug

### 问题
当模型在单次响应中同时下发多个 tool call，且其中至少一个被分发为后台任务时，存在竞态条件：如果后台任务在前台工具处理完毕之前就已结束（例如命令不存在，瞬间失败），collect_background_results() 会立即返回通知，而原代码将这些通知以 text 类型插在 tool_result 之前，构成如下错误的消息结构：

[text: <task_notification>...]   ← 在前（错误）
[tool_result: call_00...]
[tool_result: call_01...]

Anthropic API 要求：当 assistant 消息包含 tool_use block 时，紧随其后的 user 消息中，所有 tool_result 必须出现在任何 text 内容之前，否则返回：

Error 400: `tool_use` ids were found without `tool_result` blocks immediately after

### 修复
调整 agent_loop 中 user_content 的构建顺序，先放 tool_result，再追加 bg notification 的 text：

修复前（有问题）
user_content = []
bg_notifications = collect_background_results()
for notif in bg_notifications:
    user_content.append({"type": "text", "text": notif})  # text 在前 ❌
user_content.extend(results)

修复后（正确）
user_content = list(results)                               # tool_result 在前 ✅
bg_notifications = collect_background_results()
for notif in bg_notifications:
    user_content.append({"type": "text", "text": notif})  # text 在后