### PR TITLE
Fix s09 subagent tool argument mismatch

### DIFF
--- a/s08_context_compact/code.py
+++ b/s08_context_compact/code.py
@@ -204,9 +204,9 @@ SUB_TOOLS = [
 SUB_HANDLERS = {"bash": run_bash, "read_file": run_read, "write_file": run_write,
                 "edit_file": run_edit, "glob": run_glob}
 
-def spawn_subagent(task: str) -> str:
+def spawn_subagent(description: str) -> str:
     print(f"\n\033[35m[Subagent spawned]\033[0m")
-    messages = [{"role": "user", "content": task}]
+    messages = [{"role": "user", "content": description}]
     for _ in range(30):
         response = client.messages.create(model=MODEL, system=SUB_SYSTEM,
             messages=messages, tools=SUB_TOOLS, max_tokens=8000)

--- a/s09_memory/code.py
+++ b/s09_memory/code.py
@@ -416,9 +416,9 @@ SUB_TOOLS = [
 ]
 SUB_HANDLERS = {"bash": run_bash, "read_file": run_read, "write_file": run_write}
 
-def spawn_subagent(task: str) -> str:
+def spawn_subagent(description: str) -> str:
     print(f"\n\033[35m[Subagent spawned]\033[0m")
-    messages = [{"role": "user", "content": task}]
+    messages = [{"role": "user", "content": description}]
     for _ in range(30):
         response = client.messages.create(model=MODEL, system=SUB_SYSTEM,
             messages=messages, tools=SUB_TOOLS, max_tokens=8000)


### PR DESCRIPTION
Fixes a tool argument mismatch in `s09_memory/code.py`.

  The `task` tool schema defines the input field as `description`, and the
  agent loop dispatches tool calls with `handler(**block.input)`. However,
  `spawn_subagent` expected a parameter named `task`, which causes:

  `TypeError: spawn_subagent() got an unexpected keyword argument 'description'`

  This change renames the function parameter to `description` so it matches the
  tool schema.