### PR TITLE
fix(s09_memory): point read/write arrow at memory files box

### DIFF
--- a/s09_memory/images/memory-subsystems.en.svg
+++ b/s09_memory/images/memory-subsystems.en.svg
@@ -53,7 +53,7 @@
   <text x="370" y="203" fill="#475569" font-size="11" text-anchor="middle">.memory/ — MEMORY.md index + *.md files (YAML frontmatter: name / description / type)</text>
 
   <!-- Arrow: Storage → Memory Files -->
-  <path d="M 112 138 L 112 174 Q 112 180 118 180" fill="none" stroke="#7c3aed" stroke-width="1.5" marker-end="url(#arrow)"/>
+  <path d="M 112 138 L 112 180" fill="none" stroke="#7c3aed" stroke-width="1.5" marker-end="url(#arrow)"/>
   <text x="120" y="162" fill="#7c3aed" font-size="9">read/write</text>
 
   <!-- Arrow: Extraction → Memory Files -->

--- a/s09_memory/images/memory-subsystems.ja.svg
+++ b/s09_memory/images/memory-subsystems.ja.svg
@@ -53,7 +53,7 @@
   <text x="370" y="203" fill="#475569" font-size="11" text-anchor="middle">.memory/ — MEMORY.md インデックス + *.md ファイル（YAML frontmatter: name / description / type）</text>
 
   <!-- Arrow: ストレージ → Memory Files -->
-  <path d="M 112 138 L 112 174 Q 112 180 118 180" fill="none" stroke="#7c3aed" stroke-width="1.5" marker-end="url(#arrow)"/>
+  <path d="M 112 138 L 112 180" fill="none" stroke="#7c3aed" stroke-width="1.5" marker-end="url(#arrow)"/>
   <text x="120" y="162" fill="#7c3aed" font-size="9">読み/書き</text>
 
   <!-- Arrow: 抽出 → Memory Files -->

--- a/s09_memory/images/memory-subsystems.svg
+++ b/s09_memory/images/memory-subsystems.svg
@@ -53,7 +53,7 @@
   <text x="370" y="203" fill="#475569" font-size="11" text-anchor="middle">.memory/ — MEMORY.md 索引 + *.md 文件（YAML frontmatter: name / description / type）</text>
 
   <!-- Arrow: 存储 → Memory Files -->
-  <path d="M 112 138 L 112 174 Q 112 180 118 180" fill="none" stroke="#7c3aed" stroke-width="1.5" marker-end="url(#arrow)"/>
+  <path d="M 112 138 L 112 180" fill="none" stroke="#7c3aed" stroke-width="1.5" marker-end="url(#arrow)"/>
   <text x="120" y="162" fill="#7c3aed" font-size="9">写入/读取</text>
 
   <!-- Arrow: Extraction → Memory Files -->


### PR DESCRIPTION
## What

In the s09_memory subsystems diagram, the **read/write** arrow connecting *Storage* to the *Memory Files* box curved at its end and rendered horizontally on top of the dashed border. Visually it read as lying *along* the dashed line rather than *pointing to* it.

This changes the path from a curve (`M 112 138 L 112 174 Q 112 180 118 180`) to a straight vertical segment (`M 112 138 L 112 180`) that terminates at the box edge, so the arrowhead points cleanly at the box. This now matches the adjacent **write** and **overwrite** arrows.

## Files

Applied to all three variants of the diagram:
- `s09_memory/images/memory-subsystems.svg` (default / zh)
- `s09_memory/images/memory-subsystems.en.svg`
- `s09_memory/images/memory-subsystems.ja.svg`

## Before / After

- Before: arrow curves and runs along the top of the dashed box border.
- After: arrow points straight down at the box edge, consistent with the other two arrows.