### PR TITLE
fix: add json.load to deserialize run_todo_write input string

### DIFF
--- a/s05_todo_write/code.py
+++ b/s05_todo_write/code.py
@@ -28,6 +28,7 @@ Run: python s05_todo_write/code.py
 Needs: pip install anthropic python-dotenv + ANTHROPIC_API_KEY in .env
 """
 
+import json
 import os, subprocess
 from pathlib import Path
 
@@ -122,6 +123,7 @@ def run_glob(pattern: str) -> str:
 # ═══════════════════════════════════════════════════════════
 
 def run_todo_write(todos: list) -> str:
+    todos=json.loads(todos)
     global CURRENT_TODOS
     # validate required fields
     for i, t in enumerate(todos):

--- a/s06_subagent/code.py
+++ b/s06_subagent/code.py
@@ -28,6 +28,7 @@ Run: python s06_subagent/code.py
 Needs: pip install anthropic python-dotenv + ANTHROPIC_API_KEY in .env
 """
 
+import json
 import os, subprocess
 from pathlib import Path
 
@@ -122,6 +123,7 @@ def run_glob(pattern: str) -> str:
         return f"Error: {e}"
 
 def run_todo_write(todos: list) -> str:
+    todos=json.loads(todos)
     global CURRENT_TODOS
     for i, t in enumerate(todos):
         if "content" not in t or "status" not in t:

--- a/s07_skill_loading/code.py
+++ b/s07_skill_loading/code.py
@@ -26,6 +26,7 @@ Run: python s07_skill_loading/code.py
 Needs: pip install anthropic python-dotenv pyyaml + ANTHROPIC_API_KEY in .env
 """
 
+import json
 import os, subprocess
 from pathlib import Path
 import yaml
@@ -169,6 +170,7 @@ def run_glob(pattern: str) -> str:
         return f"Error: {e}"
 
 def run_todo_write(todos: list) -> str:
+    todos=json.loads(todos)
     global CURRENT_TODOS
     for i, t in enumerate(todos):
         if "content" not in t or "status" not in t:

--- a/s08_context_compact/code.py
+++ b/s08_context_compact/code.py
@@ -166,6 +166,7 @@ def run_glob(pattern: str) -> str:
     except Exception as e: return f"Error: {e}"
 
 def run_todo_write(todos: list) -> str:
+    todos = json.loads(todos) if isinstance(todos, str) else todos
     global CURRENT_TODOS
     for i, t in enumerate(todos):
         if "content" not in t or "status" not in t:

--- a/s20_comprehensive/code.py
+++ b/s20_comprehensive/code.py
@@ -458,6 +458,7 @@ def call_tool_handler(handler, args: dict, name: str) -> str:
 
 
 def run_todo_write(todos: list) -> str:
+    todos = json.loads(todos) if isinstance(todos, str) else todos
     global CURRENT_TODOS
     for i, todo in enumerate(todos):
         if "content" not in todo or "status" not in todo:


### PR DESCRIPTION
Parse input string to list via json.load(), raw incoming param is string instead of list object without deserialization, which causes tool invoke error: todos[{0}] missing 'content' or 'status'.