### PR TITLE
[codex] fix s01 prompt color handling

### DIFF
--- a/s01_agent_loop/code.py
+++ b/s01_agent_loop/code.py
@@ -29,6 +29,7 @@ Usage:
 
 import os
 import subprocess
+import sys
 
 try:
     import readline
@@ -118,10 +119,14 @@ if __name__ == "__main__":
     print("s01: Agent Loop")
     print("输入问题，回车发送。输入 q 退出。\n")
 
+    prompt = "s01 >> "
+    if sys.stdout.isatty():
+        prompt = "\001\033[36m\002s01 >> \001\033[0m\002"
+
     history = []
     while True:
         try:
-            query = input("\033[36ms01 >> \033[0m")
+            query = input(prompt)
         except (EOFError, KeyboardInterrupt):
             break
         if query.strip().lower() in ("q", "exit", ""):


### PR DESCRIPTION
## What changed

- Kept the fix local to the existing input prompt in `s01_agent_loop/code.py`.
- For an interactive terminal, the cyan ANSI prompt is wrapped with readline zero-width markers (`\001` / `\002`).
- For captured or redirected output, the prompt falls back to plain `s01 >> ` so ANSI fragments do not leak into the display.

## Why

The original prompt passed raw ANSI directly to `input()` as `\033[36ms01 >> \033[0m`. In environments that capture output or do not render ANSI escapes cleanly, this can surface as visible fragments like `[36ms01 >> [0m` instead of a cyan prompt.

## Validation

- Reproduced the raw prompt escape output before the fix.
- Verified captured output now contains plain `s01 >> ` with no `\x1b`, `[36m`, or `[0m` fragments.
- Verified TTY startup enters the prompt normally.
- Ran `python3 -m py_compile s01_agent_loop/code.py`.
- Ran `PYTHONPATH=/tmp/learn-claude-code-testdeps python3 -m pytest` (`22 passed`).