### PR TITLE
[codex] fix s01 prompt rendering

### DIFF
--- a/s01_agent_loop/code.py
+++ b/s01_agent_loop/code.py
@@ -29,6 +29,7 @@ Usage:
 
 import os
 import subprocess
+import sys
 
 try:
     import readline
@@ -121,7 +122,11 @@ if __name__ == "__main__":
     history = []
     while True:
         try:
-            query = input("\033[36ms01 >> \033[0m")
+            if sys.stdout.isatty():
+                print("\033[36ms01 >> \033[0m", end="", flush=True)
+                query = input()
+            else:
+                query = input("s01 >> ")
         except (EOFError, KeyboardInterrupt):
             break
         if query.strip().lower() in ("q", "exit", ""):


### PR DESCRIPTION
## What changed

- Updated the `s01_agent_loop/code.py` prompt rendering with a minimal local change.
- In interactive terminals, the script prints the cyan prompt directly and then calls `input()` without a prompt argument.
- In non-TTY output, the script uses a plain `s01 >> ` prompt so ANSI color fragments are not shown literally.

## Why

The original code passed raw ANSI escape sequences directly to `input()`. In some environments, those escape bytes are not rendered as color and can appear as visible fragments like `[36ms01 >> [0m`.

## Validation

- Verified captured/non-TTY output contains plain `s01 >> ` with no `\x1b`, `[36m`, or `[0m` fragments.
- Verified TTY startup enters the prompt normally.
- Ran `python3 -m py_compile s01_agent_loop/code.py`.
- Ran `PYTHONPATH=/tmp/learn-claude-code-testdeps python3 -m pytest` (`22 passed`).