### PR TITLE
docs: use canonical Kode repository links

### DIFF
--- a/README-ja.md
+++ b/README-ja.md
@@ -409,13 +409,13 @@ learn-claude-code/
 
 Skill & LSP 対応、Windows 対応、GLM / MiniMax / DeepSeek 等のオープンモデルに接続可能。インストールしてすぐ使える。
 
-GitHub: **[shareAI-lab/Kode-cli](https://github.com/shareAI-lab/Kode-cli)**
+GitHub: **[shareAI-lab/Kode-CLI](https://github.com/shareAI-lab/Kode-CLI)**
 
 ### Kode Agent SDK -- アプリにエージェント機能を埋め込む
 
 公式 Claude Code Agent SDK は内部で完全な CLI プロセスと通信する -- 同時ユーザーごとに独立のターミナルプロセスが必要。Kode SDK は独立ライブラリでユーザーごとのプロセスオーバーヘッドがなく、バックエンド、ブラウザ拡張、組み込みデバイス等に埋め込み可能。
 
-GitHub: **[shareAI-lab/Kode-agent-sdk](https://github.com/shareAI-lab/Kode-agent-sdk)**
+GitHub: **[shareAI-lab/kode-agent-sdk](https://github.com/shareAI-lab/kode-agent-sdk)**
 
 ---
 

--- a/README-zh.md
+++ b/README-zh.md
@@ -410,13 +410,13 @@ learn-claude-code/
 
 支持 Skill & LSP, 适配 Windows, 可接 GLM / MiniMax / DeepSeek 等开放模型。装完即用。
 
-GitHub: **[shareAI-lab/Kode-cli](https://github.com/shareAI-lab/Kode-cli)**
+GitHub: **[shareAI-lab/Kode-CLI](https://github.com/shareAI-lab/Kode-CLI)**
 
 ### Kode Agent SDK -- 把 Agent 能力嵌入你的应用
 
 官方 Claude Code Agent SDK 底层与完整 CLI 进程通信 -- 每个并发用户 = 一个终端进程。Kode SDK 是独立库, 无 per-user 进程开销, 可嵌入后端、浏览器插件、嵌入式设备等任意运行时。
 
-GitHub: **[shareAI-lab/Kode-agent-sdk](https://github.com/shareAI-lab/Kode-agent-sdk)**
+GitHub: **[shareAI-lab/kode-agent-sdk](https://github.com/shareAI-lab/kode-agent-sdk)**
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -415,7 +415,7 @@ After 20 lessons, you understand harness engineering from the inside out. Two pa
 
 Skill and LSP support, Windows compatible, works with GLM / MiniMax / DeepSeek and other open models. Install and go.
 
-GitHub: **[shareAI-lab/Kode-Agent](https://github.com/shareAI-lab/Kode-Agent)**
+GitHub: **[shareAI-lab/Kode-CLI](https://github.com/shareAI-lab/Kode-CLI)**
 
 ### Kode Agent SDK -- Embed Agent Capabilities in Your Application
 


### PR DESCRIPTION
## Summary

- Update README links for the Kode CLI repository to the canonical `shareAI-lab/Kode-CLI` name.
- Update Chinese and Japanese README links for the Kode SDK repository to the canonical `shareAI-lab/kode-agent-sdk` name.

## Validation

- Verified both target repositories with `gh repo view`.
- Ran `git diff --check`.
- Confirmed old redirecting link forms no longer appear in `README*.md`.
