### PR TITLE
fix: show error messages when API exceptions occur in s12-s20

### DIFF
--- a/s12_task_system/code.py
+++ b/s12_task_system/code.py
@@ -373,4 +373,6 @@ if __name__ == "__main__":
         for block in history[-1]["content"]:
             if getattr(block, "type", None) == "text":
                 print(block.text)
+            elif isinstance(block, dict) and block.get("type") == "text":
+                print(block.get("text", ""))
         print()

--- a/s13_background_tasks/code.py
+++ b/s13_background_tasks/code.py
@@ -475,4 +475,6 @@ if __name__ == "__main__":
         for block in history[-1]["content"]:
             if getattr(block, "type", None) == "text":
                 print(block.text)
+            elif isinstance(block, dict) and block.get("type") == "text":
+                print(block.get("text", ""))
         print()

--- a/s15_agent_teams/code.py
+++ b/s15_agent_teams/code.py
@@ -916,6 +916,8 @@ if __name__ == "__main__":
         for block in history[-1]["content"]:
             if getattr(block, "type", None) == "text":
                 print(block.text)
+            elif isinstance(block, dict) and block.get("type") == "text":
+                print(block.get("text", ""))
 
         # Check inbox for teammate results → inject into history
         inbox = BUS.read_inbox("lead")

--- a/s16_team_protocols/code.py
+++ b/s16_team_protocols/code.py
@@ -868,6 +868,8 @@ if __name__ == "__main__":
         for block in history[-1]["content"]:
             if getattr(block, "type", None) == "text":
                 print(block.text)
+            elif isinstance(block, dict) and block.get("type") == "text":
+                print(block.get("text", ""))
 
         # Check inbox → route protocol + inject into history
         inbox_msgs = consume_lead_inbox(route_protocol=True)

--- a/s17_autonomous_agents/code.py
+++ b/s17_autonomous_agents/code.py
@@ -800,6 +800,8 @@ if __name__ == "__main__":
         for block in history[-1]["content"]:
             if getattr(block, "type", None) == "text":
                 print(block.text)
+            elif isinstance(block, dict) and block.get("type") == "text":
+                print(block.get("text", ""))
 
         # Consume lead inbox: route protocol + inject into history
         inbox = consume_lead_inbox(route_protocol=True)

--- a/s18_worktree_isolation/code.py
+++ b/s18_worktree_isolation/code.py
@@ -984,6 +984,8 @@ if __name__ == "__main__":
         for block in history[-1]["content"]:
             if getattr(block, "type", None) == "text":
                 print(block.text)
+            elif isinstance(block, dict) and block.get("type") == "text":
+                print(block.get("text", ""))
 
         # Consume lead inbox: route protocol + inject into history
         inbox = consume_lead_inbox(route_protocol=True)

--- a/s19_mcp_plugin/code.py
+++ b/s19_mcp_plugin/code.py
@@ -1013,6 +1013,8 @@ if __name__ == "__main__":
         for block in history[-1]["content"]:
             if getattr(block, "type", None) == "text":
                 print(block.text)
+            elif isinstance(block, dict) and block.get("type") == "text":
+                print(block.get("text", ""))
 
         inbox = consume_lead_inbox(route_protocol=True)
         if inbox:

--- a/s20_comprehensive/code.py
+++ b/s20_comprehensive/code.py
@@ -2063,8 +2063,8 @@ def print_turn_assistants(messages: list, turn_start: int):
         if msg.get("role") != "assistant":
             continue
         for block in msg.get("content", []):
-            if getattr(block, "type", None) == "text":
-                terminal_print(block.text)
+            if block_type(block) == "text":
+                terminal_print(block["text"] if isinstance(block, dict) else block.text)
 
 
 def cron_autorun_loop(history: list, context: dict):


### PR DESCRIPTION
1. Fixed silent error swallowing in s12-s20's agent loops.
2. The bug: when API throws an exception, the except block stores it as a plain dict in messages, but the final display loop uses getattr(block, "type", None) which returns None for dicts (not objects), so the error message is never printed.The current state is "it runs but errors are invisible", which is the worst possible state.
3. s14 already had the fix, s20 used the existing block_type() helper.
4. Following the style of s14, fixed by adding '' elif isinstance(block, dict) and block.get("type") == "text": print(block.get("text", "")) '' to s12, s13, s15-s19, and using block_type() in s20.