### PR TITLE
fix: Fix Windows encoding and subprocess output handling in code.py

### DIFF
--- a/s06_subagent/code.py
+++ b/s06_subagent/code.py
@@ -76,14 +76,14 @@ def run_bash(command: str) -> str:
     try:
         r = subprocess.run(command, shell=True, cwd=WORKDIR,
                            capture_output=True, text=True, timeout=120)
-        out = (r.stdout + r.stderr).strip()
+        out = ((r.stdout or "")+ (r.stderr or "")).strip()
         return out[:50000] if out else "(no output)"
     except subprocess.TimeoutExpired:
         return "Error: Timeout (120s)"
 
 def run_read(path: str, limit: int | None = None) -> str:
     try:
-        lines = safe_path(path).read_text().splitlines()
+        lines = safe_path(path).read_text(encoding="utf-8", errors="replace").splitlines()
         if limit and limit < len(lines):
             lines = lines[:limit] + [f"... ({len(lines) - limit} more lines)"]
         return "\n".join(lines)
@@ -94,7 +94,7 @@ def run_write(path: str, content: str) -> str:
     try:
         file_path = safe_path(path)
         file_path.parent.mkdir(parents=True, exist_ok=True)
-        file_path.write_text(content)
+        file_path.write_text(content,encoding="utf-8")
         return f"Wrote {len(content)} bytes to {path}"
     except Exception as e:
         return f"Error: {e}"
@@ -102,10 +102,10 @@ def run_write(path: str, content: str) -> str:
 def run_edit(path: str, old_text: str, new_text: str) -> str:
     try:
         file_path = safe_path(path)
-        text = file_path.read_text()
+        text = file_path.read_text(encoding="utf-8", errors="replace")
         if old_text not in text:
             return f"Error: text not found in {path}"
-        file_path.write_text(text.replace(old_text, new_text, 1))
+        file_path.write_text(text.replace(old_text, new_text, 1),encoding="utf-8")
         return f"Edited {path}"
     except Exception as e:
         return f"Error: {e}"


### PR DESCRIPTION
**Description**

This PR addresses two runtime errors in `code.py` that can appear when tools read files or execute shell commands on Windows.

**Changes Proposed**

- Use explicit UTF-8 encoding for file reads and writes in `run_read`, `run_write`, and `run_edit`.
- Add decoding fallback such as `errors="replace"` when reading files to avoid crashes on non-GBK bytes.
- Make subprocess output concatenation null-safe in `run_bash` by treating missing `stdout` or `stderr` as empty strings.
- Optionally set `encoding="utf-8"` and `errors="replace"` in `subprocess.run`.

**Problem**

On Windows, `Path.read_text()` defaults to the system locale encoding, often GBK in Chinese environments. Reading UTF-8 files can raise:

```text
UnicodeDecodeError: 'gbk' codec can't decode byte ...
```

Also, `run_bash` concatenates subprocess output directly:

```python
r.stdout + r.stderr
```

If either value is `None`, Python raises:

```text
TypeError: unsupported operand type(s) for +: 'NoneType' and 'str'
```

**Expected Result**

File tools should handle UTF-8 content consistently across platforms, and shell command output handling should not fail when either stdout or stderr is missing.