### PR TITLE
docs: fix s03 permission gate example

### DIFF
--- a/s03_permission/README.en.md
+++ b/s03_permission/README.en.md
@@ -139,7 +139,7 @@ python s03_permission/code.py
 Try these prompts:
 
 1. `Create a file called test.txt in the current directory` (should pass through)
-2. `Delete all temporary files in /tmp` (bash + rm triggers Gate 2)
+2. `Delete the file test.txt` (bash + rm triggers Gate 2)
 3. `What files are in the current directory?` (read-only, all pass)
 4. `Try to write a file to /etc/something` (writing outside workspace triggers Gate 2)
 

--- a/s03_permission/README.ja.md
+++ b/s03_permission/README.ja.md
@@ -139,7 +139,7 @@ python s03_permission/code.py
 以下のプロンプトを試してみよう：
 
 1. `Create a file called test.txt in the current directory`（そのまま通過するはず）
-2. `Delete all temporary files in /tmp`（bash + rm でゲート 2 が発動）
+2. `Delete the file test.txt`（bash + rm でゲート 2 が発動）
 3. `What files are in the current directory?`（読み取り専用、すべて通過）
 4. `Try to write a file to /etc/something`（作業ディレクトリ外への書き込みでゲート 2 が発動）
 

--- a/s03_permission/README.md
+++ b/s03_permission/README.md
@@ -139,7 +139,7 @@ python s03_permission/code.py
 试试这些 prompt：
 
 1. `Create a file called test.txt in the current directory`（应该直接通过）
-2. `Delete all temporary files in /tmp`（bash + rm 会触发闸门 2）
+2. `Delete the file test.txt`（bash + rm 会触发闸门 2）
 3. `What files are in the current directory?`（只读，全部通过）
 4. `Try to write a file to /etc/something`（写工作区外，触发闸门 2）
 


### PR DESCRIPTION
Updates the s03 permission README examples so the Gate 2 example uses a stable workspace file deletion prompt instead of a /tmp cleanup prompt that may be hard-denied by Gate 1 depending on the generated command.
This keeps the change scoped to documentation and does not alter the teaching permission logic.
Closes #365.