### PR TITLE
[codex] Parse blockedBy strings in s12 task creation

### DIFF
--- a/s12_task_system/code.py
+++ b/s12_task_system/code.py
@@ -20,7 +20,7 @@ reactive compact, fallback model) is omitted — in real CC, tasks.ts and
 withRetry are independent layers that compose naturally.
 """
 
-import os, subprocess, json, time, random
+import ast, os, subprocess, json, time, random
 from pathlib import Path
 from dataclasses import dataclass, asdict
 
@@ -214,8 +214,28 @@ def run_write(path: str, content: str) -> str:
 
 # Task tools
 
+def _normalize_blocked_by(blockedBy):
+    if isinstance(blockedBy, str):
+        try:
+            blockedBy = json.loads(blockedBy)
+        except json.JSONDecodeError:
+            try:
+                blockedBy = ast.literal_eval(blockedBy)
+            except (SyntaxError, ValueError):
+                return None, "Error: blockedBy must be a list or JSON array string"
+    if blockedBy is None:
+        return None, None
+    if not isinstance(blockedBy, list):
+        return None, "Error: blockedBy must be a list"
+    if not all(isinstance(dep, str) for dep in blockedBy):
+        return None, "Error: blockedBy entries must be strings"
+    return blockedBy, None
+
 def run_create_task(subject: str, description: str = "",
                     blockedBy: list[str] | None = None) -> str:
+    blockedBy, error = _normalize_blocked_by(blockedBy)
+    if error:
+        return error
     task = create_task(subject, description, blockedBy)
     deps = f" (blockedBy: {', '.join(blockedBy)})" if blockedBy else ""
     print(f"  \033[34m[create] {task.subject}{deps}\033[0m")

--- a/tests/test_s12_create_task.py
+++ b/tests/test_s12_create_task.py
@@ -1,0 +1,78 @@
+import importlib.util
+import os
+import sys
+import tempfile
+import types
+import unittest
+from pathlib import Path
+
+
+MODULE_PATH = Path(__file__).resolve().parents[1] / "s12_task_system" / "code.py"
+
+
+def load_module(temp_cwd: Path):
+    fake_anthropic = types.ModuleType("anthropic")
+    fake_dotenv = types.ModuleType("dotenv")
+
+    class FakeAnthropic:
+        def __init__(self, *args, **kwargs):
+            pass
+
+    fake_anthropic.Anthropic = FakeAnthropic
+    fake_dotenv.load_dotenv = lambda override=True: None
+
+    previous = {name: sys.modules.get(name) for name in ("anthropic", "dotenv")}
+    previous_cwd = Path.cwd()
+    previous_model = os.environ.get("MODEL_ID")
+    spec = importlib.util.spec_from_file_location("s12_create_task_under_test", MODULE_PATH)
+    module = importlib.util.module_from_spec(spec)
+
+    sys.modules["anthropic"] = fake_anthropic
+    sys.modules["dotenv"] = fake_dotenv
+    os.environ["MODEL_ID"] = "test-model"
+    try:
+        os.chdir(temp_cwd)
+        spec.loader.exec_module(module)
+        return module
+    finally:
+        os.chdir(previous_cwd)
+        for name, old in previous.items():
+            if old is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = old
+        if previous_model is None:
+            os.environ.pop("MODEL_ID", None)
+        else:
+            os.environ["MODEL_ID"] = previous_model
+
+
+class CreateTaskBlockedByTests(unittest.TestCase):
+    def test_accepts_blocked_by_json_array_string(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            module = load_module(Path(tmp))
+            result = module.run_create_task("write tests", blockedBy='["task_a"]')
+
+            self.assertIn("blockedBy: task_a", result)
+            self.assertEqual(module.list_tasks()[0].blockedBy, ["task_a"])
+
+    def test_accepts_blocked_by_python_list_string(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            module = load_module(Path(tmp))
+            result = module.run_create_task("write docs", blockedBy="['task_a']")
+
+            self.assertIn("blockedBy: task_a", result)
+            self.assertEqual(module.list_tasks()[0].blockedBy, ["task_a"])
+
+    def test_rejects_non_list_blocked_by_string(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            module = load_module(Path(tmp))
+
+            self.assertEqual(
+                module.run_create_task("bad", blockedBy="not a list"),
+                "Error: blockedBy must be a list or JSON array string",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- normalize `blockedBy` before creating s12 tasks
- accept JSON array strings and Python list-repr strings from tool calls
- reject non-list or non-string dependency inputs before they reach task storage

Fixes #348.

## Validation
- `python3 -m unittest tests.test_s12_create_task`
- `python3 -m py_compile s12_task_system/code.py tests/test_s12_create_task.py`
- `git diff --check`