### PR TITLE
fix(s17): remove redundant agent_name param from idle_poll

### DIFF
--- a/s17_autonomous_agents/code.py
+++ b/s17_autonomous_agents/code.py
@@ -301,14 +301,23 @@ def scan_unclaimed_tasks() -> list[dict]:
     return unclaimed
 
 
-def idle_poll(agent_name: str, messages: list,
-              name: str, role: str) -> str:
-    """Poll for 60s. Return 'work', 'shutdown', or 'timeout'."""
+def idle_poll(name: str, messages: list, role: str) -> str:
+    """Poll for 60s. Return 'work', 'shutdown', or 'timeout'.
+
+    Args:
+        name: The teammate's name, used for inbox access and task claiming.
+        messages: The teammate's message history list (mutated in place).
+        role: The teammate's role label (used for identity re-injection).
+
+    Returns:
+        'work' if new work was found, 'shutdown' if a shutdown request was
+        received, 'timeout' if no work arrived within IDLE_TIMEOUT seconds.
+    """
     for _ in range(IDLE_TIMEOUT // IDLE_POLL_INTERVAL):
         time.sleep(IDLE_POLL_INTERVAL)
 
         # Check inbox — dispatch protocol messages first
-        inbox = BUS.read_inbox(agent_name)
+        inbox = BUS.read_inbox(name)
         if inbox:
             # Check for shutdown_request
             for msg in inbox:
@@ -331,7 +340,7 @@ def idle_poll(agent_name: str, messages: list,
         unclaimed = scan_unclaimed_tasks()
         if unclaimed:
             task = unclaimed[0]
-            result = claim_task(task["id"], agent_name)
+            result = claim_task(task["id"], name)
             if "Claimed" in result:
                 messages.append({"role": "user",
                     "content": f"<auto-claimed>Task {task['id']}: "
@@ -498,7 +507,7 @@ def spawn_teammate_thread(name: str, role: str, prompt: str) -> str:
                 break
 
             # IDLE phase (s17 new)
-            idle_result = idle_poll(name, messages, name, role)
+            idle_result = idle_poll(name, messages, role)
             if idle_result == "shutdown":
                 break
             if idle_result == "timeout":


### PR DESCRIPTION
## Summary

Closes #374

`idle_poll(agent_name, messages, name, role)` received the teammate's name twice: as `agent_name` and as `name`. The two parameters always carried the same value (the teammate's name), making `agent_name` redundant and the signature misleading.

## Changes

- Drop `agent_name` parameter, keep `name` as the single source of truth
- Update `BUS.read_inbox(agent_name)` to `BUS.read_inbox(name)` inside `idle_poll`
- Update `claim_task(task["id"], agent_name)` to `claim_task(task["id"], name)` inside `idle_poll`
- Update the caller in `spawn_teammate_thread.run()`: `idle_poll(name, messages, name, role)` to `idle_poll(name, messages, role)`
- Add a proper docstring documenting args and return values

## Verification

- `python -m py_compile s17_autonomous_agents/code.py` passes
- No remaining references to `agent_name` in the file

## Risk

Low — single file, 3 call sites updated, no behavioral change.
