### PR TITLE
fix(s12,s17): normalize blockedBy type in run_create_task

### DIFF
--- a/s12_task_system/code.py
+++ b/s12_task_system/code.py
@@ -216,6 +216,19 @@ def run_write(path: str, content: str) -> str:
 
 def run_create_task(subject: str, description: str = "",
                     blockedBy: list[str] | None = None) -> str:
+    # Normalize blockedBy: LLMs sometimes return a string-form list
+    # (e.g. "['task_001']") or a single string instead of a real list.
+    if isinstance(blockedBy, str):
+        try:
+            parsed = json.loads(blockedBy)
+            blockedBy = parsed if isinstance(parsed, list) else [str(parsed)]
+        except (json.JSONDecodeError, ValueError):
+            cleaned = blockedBy.strip().strip("[]'\" ")
+            blockedBy = ([b.strip().strip("'\"") for b in cleaned.split(",")
+                          if b.strip()] or None)
+    elif blockedBy is not None and not isinstance(blockedBy, list):
+        blockedBy = [str(blockedBy)]
+
     task = create_task(subject, description, blockedBy)
     deps = f" (blockedBy: {', '.join(blockedBy)})" if blockedBy else ""
     print(f"  \033[34m[create] {task.subject}{deps}\033[0m")

--- a/s17_autonomous_agents/code.py
+++ b/s17_autonomous_agents/code.py
@@ -582,6 +582,19 @@ def run_review_plan(request_id: str, approve: bool,
 
 def run_create_task(subject: str, description: str = "",
                     blockedBy: list[str] | None = None) -> str:
+    # Normalize blockedBy: LLMs sometimes return a string-form list
+    # (e.g. "['task_001']") or a single string instead of a real list.
+    if isinstance(blockedBy, str):
+        try:
+            parsed = json.loads(blockedBy)
+            blockedBy = parsed if isinstance(parsed, list) else [str(parsed)]
+        except (json.JSONDecodeError, ValueError):
+            cleaned = blockedBy.strip().strip("[]'\" ")
+            blockedBy = ([b.strip().strip("'\"") for b in cleaned.split(",")
+                          if b.strip()] or None)
+    elif blockedBy is not None and not isinstance(blockedBy, list):
+        blockedBy = [str(blockedBy)]
+
     task = create_task(subject, description, blockedBy)
     deps = f" (blockedBy: {', '.join(blockedBy)})" if blockedBy else ""
     print(f"  \033[34m[create] {task.subject}{deps}\033[0m")


### PR DESCRIPTION
## Summary

Closes #348

LLMs may return `blockedBy` as a string-form list (e.g. `"['task_001']"`) or a single string instead of a real `list`, which causes `can_start()` to iterate over characters of the string and breaks dependency checking.

## Changes

Add type normalization at the entry of `run_create_task` in both sessions that have this function:

- `s12_task_system/code.py`
- `s17_autonomous_agents/code.py`

The normalization handles three cases:
1. **String-form list** (e.g. `"['task_001', 'task_002']"`): parse with `json.loads`, fallback to comma-split if JSON parsing fails.
2. **Single string** (e.g. `"task_001"`): wrap into a single-element list.
3. **Non-list, non-string value**: coerce to string and wrap into a list.

## Verification

- `python -m py_compile` passes for both files
- No behavioral change when `blockedBy` is already a valid list or None

## Risk

Low — defensive normalization at the entry point, no change to downstream logic.
