### PR TITLE
fix(s09,s10,s11,s_full): /inbox command should peek, not drain

### DIFF
--- a/agents/s09_agent_teams.py
+++ b/agents/s09_agent_teams.py
@@ -391,7 +391,14 @@ if __name__ == "__main__":
             print(TEAM.list_all())
             continue
         if query.strip() == "/inbox":
-            print(json.dumps(BUS.read_inbox("lead"), indent=2))
+            # Peek without draining — read_inbox() clears the file, which
+            # would make the lead agent miss pending messages.
+            inbox_path = INBOX_DIR / "lead.jsonl"
+            if inbox_path.exists():
+                msgs = [json.loads(line) for line in inbox_path.read_text().strip().splitlines() if line]
+                print(json.dumps(msgs, indent=2))
+            else:
+                print("[]")
             continue
         history.append({"role": "user", "content": query})
         agent_loop(history)

--- a/agents/s10_team_protocols.py
+++ b/agents/s10_team_protocols.py
@@ -472,7 +472,14 @@ if __name__ == "__main__":
             print(TEAM.list_all())
             continue
         if query.strip() == "/inbox":
-            print(json.dumps(BUS.read_inbox("lead"), indent=2))
+            # Peek without draining — read_inbox() clears the file, which
+            # would make the lead agent miss pending messages.
+            inbox_path = INBOX_DIR / "lead.jsonl"
+            if inbox_path.exists():
+                msgs = [json.loads(line) for line in inbox_path.read_text().strip().splitlines() if line]
+                print(json.dumps(msgs, indent=2))
+            else:
+                print("[]")
             continue
         history.append({"role": "user", "content": query})
         agent_loop(history)

--- a/agents/s11_autonomous_agents.py
+++ b/agents/s11_autonomous_agents.py
@@ -566,7 +566,14 @@ if __name__ == "__main__":
             print(TEAM.list_all())
             continue
         if query.strip() == "/inbox":
-            print(json.dumps(BUS.read_inbox("lead"), indent=2))
+            # Peek without draining — read_inbox() clears the file, which
+            # would make the lead agent miss pending messages.
+            inbox_path = INBOX_DIR / "lead.jsonl"
+            if inbox_path.exists():
+                msgs = [json.loads(line) for line in inbox_path.read_text().strip().splitlines() if line]
+                print(json.dumps(msgs, indent=2))
+            else:
+                print("[]")
             continue
         if query.strip() == "/tasks":
             TASKS_DIR.mkdir(exist_ok=True)

--- a/agents/s_full.py
+++ b/agents/s_full.py
@@ -728,7 +728,14 @@ if __name__ == "__main__":
             print(TEAM.list_all())
             continue
         if query.strip() == "/inbox":
-            print(json.dumps(BUS.read_inbox("lead"), indent=2))
+            # Peek without draining — read_inbox() clears the file, which
+            # would make the lead agent miss pending messages.
+            inbox_path = INBOX_DIR / "lead.jsonl"
+            if inbox_path.exists():
+                msgs = [json.loads(line) for line in inbox_path.read_text().strip().splitlines() if line]
+                print(json.dumps(msgs, indent=2))
+            else:
+                print("[]")
             continue
         history.append({"role": "user", "content": query})
         agent_loop(history)


### PR DESCRIPTION
## Summary

Closes #252

The `/inbox` REPL command is intended to let users **view** the lead's inbox contents. However, it called `BUS.read_inbox("lead")`, which uses **drain semantics** — reading the inbox clears the file. This means users viewing the inbox would lose all pending messages before the lead agent could process them.

## Root Cause

`MessageBus.read_inbox()` is designed for the agent loop (read-and-drain to avoid reprocessing). But the `/inbox` user command should use **peek semantics** (read-only).

```python
# Before — drains the inbox
if query.strip() == "/inbox":
    print(json.dumps(BUS.read_inbox("lead"), indent=2))
    continue

# After — peeks without draining
if query.strip() == "/inbox":
    inbox_path = INBOX_DIR / "lead.jsonl"
    if inbox_path.exists():
        msgs = [json.loads(line) for line in inbox_path.read_text().strip().splitlines() if line]
        print(json.dumps(msgs, indent=2))
    else:
        print("[]")
    continue
```

## Files Changed

The same bug exists in 4 files (all under `agents/`):

- `agents/s09_agent_teams.py`
- `agents/s10_team_protocols.py`
- `agents/s11_autonomous_agents.py`
- `agents/s_full.py`

## Verification

- `python -m py_compile` passes for all 4 files
- The agent loop's `BUS.read_inbox("lead")` call (in `agent_loop`) is unchanged — only the user-facing `/inbox` command is fixed

## Risk

Low — only the user-facing REPL command is changed; the agent loop's inbox consumption logic is untouched.
