### PR TITLE
fix(s17): remove redundant agent_name param from idle_poll (#374)

### DIFF
--- a/README-zh.md
+++ b/README-zh.md
@@ -30,15 +30,29 @@ Agent 的核心是一个神经网络 -- Transformer、RNN、一个被训练出�
 
 ### Agent 不是什么
 
-"Agent" 这个词已经被一整个提示词水管工产业劫持了。
+"Agent" 这个词，已经被一整条提示词流水线产业劫持了。
 
-拖拽式工作流构建器。无代码 "AI Agent" 平台。提示词链编排库。它们共享同一个幻觉：把 LLM API 调用用 if-else 分支、节点图、硬编码路由逻辑串在一起就算是 "构建 Agent" 了。
+拖拽式工作流构建器。无代码 "AI Agent" 平台。提示词链编排库。
 
-不是的。它们做出来的东西是鲁布·戈德堡机械 -- 一个过度工程化的、脆弱的过程式规则流水线，LLM 被楔在里面当一个美化了的文本补全节点。那不是 Agent。那是一个有着宏大妄想的 shell 脚本。
+它们共享同一个幻觉：把 LLM API 调用，用 if-else 分支、节点图、硬编码路由串在一起，就算是 "构建 Agent" 了。
 
-**提示词水管工式 "Agent" 是不做模型的程序员的意淫。** 他们试图通过堆叠过程式逻辑来暴力模拟智能 -- 庞大的规则树、节点图、链式提示词瀑布流 -- 然后祈祷足够多的胶水代码能涌现出自主行为。不会的。你不可能通过工程手段编码出 agency。Agency 是学出来的，不是编出来的。
+不是。
 
-那些系统从诞生之日起就已经死了：脆弱、不可扩展、根本不具备泛化能力。它们是 GOFAI（Good Old-Fashioned AI，经典符号 AI）的现代还魂 -- 几十年前就被学界抛弃的符号规则系统，现在喷了一层 LLM 的漆又登场了。换了个包装，同一条死路。
+它们做出来的是鲁布·戈德堡机械——过度工程化、脆弱的过程式规则流水线。LLM 被楔在里面，当一个美化了的文本补全节点。
+
+那不是 Agent。那是一个披着宏大外衣的 shell 脚本。
+
+试图通过堆叠过程式逻辑来暴力模拟智能——庞大的规则树、节点图、链式提示词瀑布——然后祈祷足够多的胶水代码能自发涌现出自主行为。
+
+不会的。
+
+Agency 不可能被编码。Agency 是学出来的，不是编出来的。
+
+那些系统从诞生起就已经死了。脆弱。不可扩展。毫无泛化能力。
+
+它们是 GOFAI（Good Old-Fashioned AI，经典符号 AI）的现代回魂——几十年前被学界抛弃的符号规则系统，现在喷了一层 LLM 的漆，又登场了。
+
+换了个包装，同一条死路。
 
 ### 心智转换：从 "开发 Agent" 到开发 Harness
 
@@ -378,14 +392,7 @@ flowchart TD
 | [s18](./s18_worktree_isolation/) | Worktree Isolation | `WorktreeRecord` / 任务-目录绑定 |
 | [s19](./s19_mcp_plugin/) | MCP Plugin | 多传输 / 通道路由 / 工具池组装 |
 | [s20](./s20_comprehensive/) | Comprehensive Agent | 全部机制归到一个循环 |
-
-### 补充教程
-
-独立于主 20 章主线的补充课程。
-
-| 教程 | 主题 | 代码 | 文档 |
-|---|---|---|---|
-| s13-补充 | 系统提示词（动态环境） | [s13_system_prompt_manager.py](./s13_system_prompt_manager.py) | [en](./docs/en/s13-system-prompts.md) · [zh](./docs/zh/s13-system-prompts.md) |
+| [s21](./s21_system_prompts_analysis/) | System Prompts 分析 | 分析 Claude Code 真实的 525+ 条提示词 |
 
 ## 项目结构
 
@@ -401,6 +408,7 @@ learn-claude-code/
   ...
   s19_mcp_plugin/
   s20_comprehensive/       # 终点章
+  s21_system_prompts_analysis/  # 分析篇：读懂 Claude Code 的提示词
   agents/                  # 旧 12 章可运行副本 + s_full.py
   skills/                  # s07 使用的 skill 文件
   docs/                    # 旧 12 章文档，过渡期保留

--- a/README-zh.md
+++ b/README-zh.md
@@ -379,6 +379,14 @@ flowchart TD
 | [s19](./s19_mcp_plugin/) | MCP Plugin | 多传输 / 通道路由 / 工具池组装 |
 | [s20](./s20_comprehensive/) | Comprehensive Agent | 全部机制归到一个循环 |
 
+### 补充教程
+
+独立于主 20 章主线的补充课程。
+
+| 教程 | 主题 | 代码 | 文档 |
+|---|---|---|---|
+| s13-补充 | 系统提示词（动态环境） | [s13_system_prompt_manager.py](./s13_system_prompt_manager.py) | [en](./docs/en/s13-system-prompts.md) · [zh](./docs/zh/s13-system-prompts.md) |
+
 ## 项目结构
 
 ```

--- a/README.md
+++ b/README.md
@@ -328,6 +328,14 @@ flowchart TD
 | [s19](./s19_mcp_plugin/) | MCP Plugin | multi-transport / channel routing / tool pool assembly |
 | [s20](./s20_comprehensive/) | Comprehensive Agent | all mechanisms around one loop |
 
+### Supplementary Tutorials
+
+Standalone lessons that complement the main 20-lesson track.
+
+| Tutorial | Topic | Code | Docs |
+|---|---|---|---|
+| s13-supplementary | System Prompts (Dynamic Env) | [s13_system_prompt_manager.py](./s13_system_prompt_manager.py) | [en](./docs/en/s13-system-prompts.md) · [zh](./docs/zh/s13-system-prompts.md) |
+
 ---
 
 ## How to Read

--- a/docs/en/s13-system-prompts.md
+++ b/docs/en/s13-system-prompts.md
@@ -1,0 +1,183 @@
+# s13: System Prompts — Dynamic Environment-Aware Assembly
+
+`s01 > s02 > s03 > s04 > s05 > s06 | s07 > s08 > s09 > s10 > s11 > s12 > [ s13 ]`
+
+> *"The prompt knows where it runs"* — OS, paths, shell, user, all injected at runtime.
+>
+> **Harness layer**: Prompt — assembled from real environment state, never hardcoded.
+
+## Problem
+
+A system prompt that says `"You are a coding agent at /home/user/project"` works on one machine. Move to another user, another OS, another shell — and the prompt lies. The agent then suggests commands that don't exist, paths that don't resolve, tools that aren't installed.
+
+Hardcoding environment facts causes three failure modes:
+
+1. **Wrong OS commands** — `ls` vs `dir`, `cat` vs `type`, `/usr/bin/python3` vs `C:\Python313\python.exe`
+2. **Wrong paths** — `/home/alice` vs `C:\Users\alice`, `/tmp` vs `%TEMP%`
+3. **Wrong shell semantics** — bash globbing, PowerShell cmdlets, cmd.exe quirks
+
+The system prompt must reflect the *actual* runtime environment: which OS, which shell, which user, which paths exist, which tools are on PATH.
+
+## Solution
+
+```
+Environment probing              System prompt assembly
++-----------------------+        +-----------------------------+
+| OS / platform         |        | [identity]                  |
+| Python version        | -----> | [environment]               |
+| Working directory     |        | [tools_available]           |
+| Home / temp paths     |        | [workspace]                 |
+| Shell + env vars      |        | [safety_constraints]        |
+| Tools on PATH         |        +-----------------------------+
+| User / hostname       |                     |
++-----------------------+                     v
+                                    Printed / sent to LLM
+```
+
+Six sections, two loading strategies:
+
+| Section           | Strategy  | Content                                  | Source                     |
+|-------------------|-----------|------------------------------------------|----------------------------|
+| identity          | always    | who the agent is, how to behave          | static                     |
+| environment       | always    | OS, Python, shell, user, host            | `platform`, `os`, `getpass`|
+| tools_available   | always    | which tools exist on PATH                | `shutil.which`             |
+| workspace         | always    | cwd, home, temp, project root            | `pathlib`, `os`            |
+| safety_constraints| always    | path boundaries, dangerous commands      | static rules               |
+| project_context   | on-demand | git branch, project files (if any)       | `subprocess`, `pathlib`    |
+
+Key design: every fact in the prompt is *probed at runtime*, not typed by hand. The same script produces a correct prompt on Windows, macOS, and Linux without modification.
+
+## How It Works
+
+### 1. Probe the OS and platform
+
+```python
+import platform, os
+
+def probe_os() -> dict:
+    return {
+        "system": platform.system(),        # Windows / Darwin / Linux
+        "release": platform.release(),      # 10 / 23.4.0 / 5.15.0
+        "machine": platform.machine(),      # AMD64 / arm64 / x86_64
+        "processor": platform.processor() or platform.machine(),
+        "python": platform.python_version(),
+        "is_windows": os.name == "nt",
+        "is_macos": platform.system() == "Darwin",
+        "is_linux": platform.system() == "Linux",
+    }
+```
+
+### 2. Probe paths
+
+```python
+from pathlib import Path
+
+def probe_paths() -> dict:
+    return {
+        "cwd": str(Path.cwd()),
+        "home": str(Path.home()),
+        "temp": str(Path(os.environ.get("TEMP", os.environ.get("TMPDIR", "/tmp")))),
+        "python_executable": sys.executable,
+    }
+```
+
+### 3. Probe the shell and user
+
+```python
+import getpass
+
+def probe_user_shell() -> dict:
+    return {
+        "user": getpass.getuser(),
+        "shell": os.environ.get("SHELL") or os.environ.get("COMSPEC", "unknown"),
+        "hostname": platform.node(),
+    }
+```
+
+### 4. Probe available tools on PATH
+
+```python
+import shutil
+
+def probe_tools() -> dict:
+    candidates = ["git", "python", "python3", "node", "npm", "docker", "make", "curl"]
+    return {name: shutil.which(name) for name in candidates if shutil.which(name)}
+```
+
+### 5. Assemble the system prompt
+
+```python
+def assemble_system_prompt(env: dict) -> str:
+    sections = [
+        IDENTITY,
+        format_environment(env),
+        format_tools(env["tools"]),
+        format_workspace(env["paths"]),
+        SAFETY_CONSTRAINTS,
+    ]
+    if env.get("project"):
+        sections.append(format_project(env["project"]))
+    return "\n\n".join(sections)
+```
+
+### 6. Cache by environment fingerprint
+
+Re-probing every turn is wasteful. Hash the environment dict; re-assemble only when it changes.
+
+```python
+def get_system_prompt(env: dict) -> str:
+    key = json.dumps(env, sort_keys=True, default=str)
+    if key == _last_key and _last_prompt:
+        return _last_prompt  # cache hit
+    _last_key = key
+    _last_prompt = assemble_system_prompt(env)
+    return _last_prompt
+```
+
+## What Changed From s10
+
+s10 introduced `PROMPT_SECTIONS` and `assemble_system_prompt(context)` but the context was minimal — just `enabled_tools`, `workspace`, and `memories`. The prompt still assumed a Unix-like environment.
+
+| Aspect              | s10                          | s13                                  |
+|---------------------|------------------------------|--------------------------------------|
+| OS detection        | None                         | `platform.system()` + flags          |
+| Path resolution     | Hardcoded `WORKDIR`          | `Path.cwd()`, `Path.home()`, `TEMP`  |
+| Shell awareness     | None                         | `SHELL` / `COMSPEC` probed           |
+| Tool availability   | Static list in `TOOLS`       | `shutil.which()` probes PATH         |
+| User / host         | None                         | `getpass.getuser()`, `platform.node()`|
+| Project context     | None                         | git branch + project files (optional)|
+| Cache key           | `json.dumps(context)`        | `json.dumps(env)` (broader fingerprint)|
+
+## Try It
+
+```sh
+cd learn-claude-code
+python s13_system_prompt_manager.py
+```
+
+What to watch for:
+
+1. The script prints each probed environment fact as it's gathered
+2. The final assembled system prompt is printed in a fenced block
+3. Running on Windows shows `system: Windows`, `shell: ...powershell...`
+4. Running on macOS shows `system: Darwin`, `shell: /bin/zsh`
+5. Re-running shows `[cache hit]` because the environment didn't change
+
+Try these experiments:
+
+1. `python s13_system_prompt_manager.py` — print the assembled prompt
+2. `python s13_system_prompt_manager.py --json` — emit the env dict as JSON
+3. `python s13_system_prompt_manager.py --raw` — print only the prompt, no decorations
+4. Change directory (`cd /tmp && python .../s13_system_prompt_manager.py`) — watch the workspace section update
+
+## Why This Matters
+
+A system prompt that lies is worse than no system prompt. The agent trusts it. If it says `"Use bash"` on Windows, the agent runs `ls -la` and gets `CommandNotFoundException`. If it says `"Working directory: /home/user"` but cwd is actually `C:\Users\user`, every relative path the agent suggests is wrong.
+
+Dynamic probing makes the prompt *honest*. The same code runs anywhere and produces a prompt that matches reality. This is the foundation for portable agents: ship one codebase, run on any OS, the prompt adapts itself.
+
+## What's Next
+
+The prompt now reflects the environment. But the agent still can't recover when a tool call fails — wrong path, missing file, permission denied. The next step is error recovery: catch, classify, retry with a fix.
+
+<!-- translation-sync: en@v1 -->

--- a/docs/zh/s13-system-prompts.md
+++ b/docs/zh/s13-system-prompts.md
@@ -1,0 +1,183 @@
+# s13：系统提示词 —— 动态环境感知拼装
+
+`s01 > s02 > s03 > s04 > s05 > s06 | s07 > s08 > s09 > s10 > s11 > s12 > [ s13 ]`
+
+> *"提示词知道自己运行在哪里"* —— OS、路径、Shell、用户，全部运行时注入。
+>
+> **Harness 层**：提示词 —— 基于真实环境状态拼装，绝不硬编码。
+
+## 问题
+
+一个写着 `"You are a coding agent at /home/user/project"` 的系统提示词，只在一台机器上能跑。换一个用户、换一个 OS、换一个 Shell —— 提示词就开始撒谎。智能体接着会建议不存在的命令、解析不了的路径、没安装的工具。
+
+硬编码环境信息会导致三类故障：
+
+1. **OS 命令错误** —— `ls` vs `dir`、`cat` vs `type`、`/usr/bin/python3` vs `C:\Python313\python.exe`
+2. **路径错误** —— `/home/alice` vs `C:\Users\alice`、`/tmp` vs `%TEMP%`
+3. **Shell 语义错误** —— bash 通配符、PowerShell cmdlet、cmd.exe 怪癖
+
+系统提示词必须反映*真实的*运行时环境：哪个 OS、哪个 Shell、哪个用户、哪些路径存在、哪些工具在 PATH 上。
+
+## 方案
+
+```
+环境探测                            系统提示词拼装
++-----------------------+        +-----------------------------+
+| OS / 平台             |        | [identity]                  |
+| Python 版本           | -----> | [environment]               |
+| 工作目录              |        | [tools_available]           |
+| Home / temp 路径      |        | [workspace]                 |
+| Shell + 环境变量      |        | [safety_constraints]        |
+| PATH 上的工具         |        +-----------------------------+
+| 用户 / 主机名         |                     |
++-----------------------+                     v
+                                    打印 / 发送给 LLM
+```
+
+六个分段，两种加载策略：
+
+| 分段               | 策略      | 内容                                     | 来源                       |
+|-------------------|-----------|------------------------------------------|----------------------------|
+| identity          | 始终加载  | 智能体身份与行为准则                     | 静态                       |
+| environment       | 始终加载  | OS、Python、Shell、用户、主机            | `platform`, `os`, `getpass`|
+| tools_available   | 始终加载  | PATH 上存在哪些工具                      | `shutil.which`             |
+| workspace         | 始终加载  | cwd、home、temp、项目根                  | `pathlib`, `os`            |
+| safety_constraints| 始终加载  | 路径边界、危险命令                       | 静态规则                   |
+| project_context   | 按需加载  | git 分支、项目文件（如有）               | `subprocess`, `pathlib`    |
+
+核心设计：提示词中的每一个事实都是*运行时探测*出来的，不是手敲的。同一份脚本在 Windows、macOS、Linux 上都能产出正确的提示词，无需改动。
+
+## 工作原理
+
+### 1. 探测 OS 与平台
+
+```python
+import platform, os
+
+def probe_os() -> dict:
+    return {
+        "system": platform.system(),        # Windows / Darwin / Linux
+        "release": platform.release(),      # 10 / 23.4.0 / 5.15.0
+        "machine": platform.machine(),      # AMD64 / arm64 / x86_64
+        "processor": platform.processor() or platform.machine(),
+        "python": platform.python_version(),
+        "is_windows": os.name == "nt",
+        "is_macos": platform.system() == "Darwin",
+        "is_linux": platform.system() == "Linux",
+    }
+```
+
+### 2. 探测路径
+
+```python
+from pathlib import Path
+
+def probe_paths() -> dict:
+    return {
+        "cwd": str(Path.cwd()),
+        "home": str(Path.home()),
+        "temp": str(Path(os.environ.get("TEMP", os.environ.get("TMPDIR", "/tmp")))),
+        "python_executable": sys.executable,
+    }
+```
+
+### 3. 探测 Shell 与用户
+
+```python
+import getpass
+
+def probe_user_shell() -> dict:
+    return {
+        "user": getpass.getuser(),
+        "shell": os.environ.get("SHELL") or os.environ.get("COMSPEC", "unknown"),
+        "hostname": platform.node(),
+    }
+```
+
+### 4. 探测 PATH 上的可用工具
+
+```python
+import shutil
+
+def probe_tools() -> dict:
+    candidates = ["git", "python", "python3", "node", "npm", "docker", "make", "curl"]
+    return {name: shutil.which(name) for name in candidates if shutil.which(name)}
+```
+
+### 5. 拼装系统提示词
+
+```python
+def assemble_system_prompt(env: dict) -> str:
+    sections = [
+        IDENTITY,
+        format_environment(env),
+        format_tools(env["tools"]),
+        format_workspace(env["paths"]),
+        SAFETY_CONSTRAINTS,
+    ]
+    if env.get("project"):
+        sections.append(format_project(env["project"]))
+    return "\n\n".join(sections)
+```
+
+### 6. 按环境指纹缓存
+
+每轮都重新探测太浪费。对环境 dict 做哈希，只在变化时才重新拼装。
+
+```python
+def get_system_prompt(env: dict) -> str:
+    key = json.dumps(env, sort_keys=True, default=str)
+    if key == _last_key and _last_prompt:
+        return _last_prompt  # cache hit
+    _last_key = key
+    _last_prompt = assemble_system_prompt(env)
+    return _last_prompt
+```
+
+## 相比 s10 的演进
+
+s10 引入了 `PROMPT_SECTIONS` 和 `assemble_system_prompt(context)`，但 context 很单薄 —— 只有 `enabled_tools`、`workspace`、`memories`。提示词仍然假设是 Unix 环境。
+
+| 维度               | s10                          | s13                                  |
+|-------------------|------------------------------|--------------------------------------|
+| OS 探测            | 无                           | `platform.system()` + 标志位         |
+| 路径解析           | 硬编码 `WORKDIR`             | `Path.cwd()`、`Path.home()`、`TEMP`  |
+| Shell 感知         | 无                           | 探测 `SHELL` / `COMSPEC`             |
+| 工具可用性         | `TOOLS` 静态列表             | `shutil.which()` 探测 PATH           |
+| 用户 / 主机        | 无                           | `getpass.getuser()`、`platform.node()`|
+| 项目上下文         | 无                           | git 分支 + 项目文件（可选）          |
+| 缓存键             | `json.dumps(context)`        | `json.dumps(env)`（更宽的指纹）      |
+
+## 试一下
+
+```sh
+cd learn-claude-code
+python s13_system_prompt_manager.py
+```
+
+观察重点：
+
+1. 脚本会逐条打印探测到的环境信息
+2. 最终拼装好的系统提示词会以代码块形式打印
+3. 在 Windows 上会显示 `system: Windows`、`shell: ...powershell...`
+4. 在 macOS 上会显示 `system: Darwin`、`shell: /bin/zsh`
+5. 再次运行会显示 `[cache hit]`，因为环境没变
+
+试试这些实验：
+
+1. `python s13_system_prompt_manager.py` —— 打印拼装好的提示词
+2. `python s13_system_prompt_manager.py --json` —— 输出环境 dict 的 JSON
+3. `python s13_system_prompt_manager.py --raw` —— 只打印提示词，不带装饰
+4. 切换目录（`cd /tmp && python .../s13_system_prompt_manager.py`）—— 观察 workspace 分段的变化
+
+## 为什么这件事重要
+
+会撒谎的系统提示词比没有提示词更糟。智能体会信任它。如果提示词说 `"Use bash"` 但实际在 Windows 上，智能体执行 `ls -la` 就会收到 `CommandNotFoundException`。如果提示词说 `"Working directory: /home/user"` 但 cwd 实际是 `C:\Users\user`，智能体建议的每一个相对路径都是错的。
+
+动态探测让提示词*诚实*。同一份代码在任何地方运行，产出的提示词都与现实匹配。这是可移植智能体的基石：发布一份代码，跑在任意 OS 上，提示词自己适配。
+
+## 下一步
+
+提示词现在能反映环境了。但智能体在工具调用失败时仍然无法恢复 —— 路径错误、文件缺失、权限拒绝。下一步是错误恢复：捕获、分类、修复后重试。
+
+<!-- translation-sync: zh@v1 -->

--- a/s13_system_prompt_manager.py
+++ b/s13_system_prompt_manager.py
@@ -1,0 +1,410 @@
+#!/usr/bin/env python3
+"""
+s13_system_prompt_manager.py - Dynamic Environment-Aware System Prompt Assembly
+
+Demonstrates how to probe the real runtime environment (OS, paths, shell, user,
+available tools) and assemble a system prompt that reflects it honestly. The
+same script produces a correct prompt on Windows, macOS, and Linux without
+modification.
+
+Run:  python s13_system_prompt_manager.py
+      python s13_system_prompt_manager.py --json   # emit env dict as JSON
+      python s13_system_prompt_manager.py --raw    # print only the prompt
+
+No API key required — this script only assembles and prints the prompt.
+"""
+
+from __future__ import annotations
+
+import argparse
+import getpass
+import json
+import os
+import platform
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+
+# ── Static prompt fragments ──────────────────────────────────────────────────
+
+IDENTITY = (
+    "You are a coding agent. Act, don't explain. "
+    "Use tools to solve tasks. Be concise."
+)
+
+SAFETY_CONSTRAINTS = (
+    "Safety constraints:\n"
+    "- Never execute commands that escape the working directory.\n"
+    "- Never delete files outside the workspace.\n"
+    "- Confirm with the user before running destructive operations.\n"
+    "- Treat all paths as relative to the working directory unless absolute."
+)
+
+
+# ── Environment probes ───────────────────────────────────────────────────────
+
+def probe_os() -> dict[str, Any]:
+    """Probe operating system and platform information.
+
+    Returns:
+        dict with keys: system, release, version, machine, processor,
+        python_version, is_windows, is_macos, is_linux
+    """
+    system = platform.system()
+    return {
+        "system": system,
+        "release": platform.release(),
+        "version": platform.version(),
+        "machine": platform.machine(),
+        "processor": platform.processor() or platform.machine(),
+        "python_version": platform.python_version(),
+        "python_implementation": platform.python_implementation(),
+        "is_windows": system == "Windows",
+        "is_macos": system == "Darwin",
+        "is_linux": system == "Linux",
+    }
+
+
+def probe_paths() -> dict[str, str]:
+    """Probe important filesystem paths.
+
+    Returns:
+        dict with keys: cwd, home, temp, python_executable, path_separator
+    """
+    temp_dir = (
+        os.environ.get("TEMP")
+        or os.environ.get("TMPDIR")
+        or os.environ.get("TMP")
+        or "/tmp"
+    )
+    return {
+        "cwd": str(Path.cwd()),
+        "home": str(Path.home()),
+        "temp": str(Path(temp_dir)),
+        "python_executable": sys.executable,
+        "path_separator": os.sep,
+        "path_list_separator": os.pathsep,
+    }
+
+
+def probe_user_shell() -> dict[str, str]:
+    """Probe current user and shell information.
+
+    Returns:
+        dict with keys: user, shell, hostname, terminal
+    """
+    try:
+        user = getpass.getuser()
+    except Exception:
+        user = os.environ.get("USER") or os.environ.get("USERNAME") or "unknown"
+
+    shell = (
+        os.environ.get("SHELL")
+        or os.environ.get("COMSPEC")
+        or os.environ.get("shell")
+        or "unknown"
+    )
+    terminal = (
+        os.environ.get("TERM")
+        or os.environ.get("WT_SESSION")  # Windows Terminal
+        or "unknown"
+    )
+
+    return {
+        "user": user,
+        "shell": shell,
+        "hostname": platform.node(),
+        "terminal": terminal,
+    }
+
+
+def probe_tools() -> dict[str, str]:
+    """Probe which common development tools are available on PATH.
+
+    Returns:
+        dict mapping tool name -> absolute path (only for tools found)
+    """
+    candidates = [
+        "git", "python", "python3", "py",
+        "node", "npm", "pnpm", "yarn",
+        "docker", "make", "cmake",
+        "curl", "wget",
+        "rg", "fd", "jq",
+        "code", "vim", "nvim",
+    ]
+    found: dict[str, str] = {}
+    for name in candidates:
+        path = shutil.which(name)
+        if path:
+            found[name] = path
+    return found
+
+
+def probe_project() -> dict[str, Any]:
+    """Probe project context: git branch, project files.
+
+    Returns:
+        dict with keys: is_git_repo, branch (optional), project_files
+    """
+    cwd = Path.cwd()
+    info: dict[str, Any] = {
+        "is_git_repo": (cwd / ".git").exists(),
+        "project_files": [],
+    }
+
+    if info["is_git_repo"]:
+        try:
+            result = subprocess.run(
+                ["git", "rev-parse", "--abbrev-ref", "HEAD"],
+                capture_output=True, text=True, timeout=5,
+            )
+            if result.returncode == 0:
+                info["branch"] = result.stdout.strip()
+        except (subprocess.TimeoutExpired, FileNotFoundError):
+            pass
+
+    markers = ["README.md", "package.json", "pyproject.toml", "requirements.txt",
+               "Cargo.toml", "go.mod", ".env.example"]
+    info["project_files"] = [m for m in markers if (cwd / m).exists()]
+
+    return info
+
+
+def probe_environment() -> dict[str, Any]:
+    """Run all probes and return a combined environment dict.
+
+    Returns:
+        dict with keys: os, paths, user_shell, tools, project, timestamp
+    """
+    return {
+        "os": probe_os(),
+        "paths": probe_paths(),
+        "user_shell": probe_user_shell(),
+        "tools": probe_tools(),
+        "project": probe_project(),
+    }
+
+
+# ── Prompt section formatters ────────────────────────────────────────────────
+
+def format_environment(os_info: dict[str, Any], user_shell: dict[str, str]) -> str:
+    """Format the environment section of the system prompt.
+
+    Args:
+        os_info: output of probe_os()
+        user_shell: output of probe_user_shell()
+
+    Returns:
+        Formatted string describing the runtime environment.
+    """
+    lines = [
+        "Environment:",
+        f"  OS: {os_info['system']} {os_info['release']} ({os_info['machine']})",
+        f"  Python: {os_info['python_version']} ({os_info['python_implementation']})",
+        f"  User: {user_shell['user']}@{user_shell['hostname']}",
+        f"  Shell: {user_shell['shell']}",
+    ]
+    if os_info["is_windows"]:
+        lines.append("  Platform note: Windows — use backslash paths, "
+                     "prefer PowerShell or cmd.exe commands.")
+    elif os_info["is_macos"]:
+        lines.append("  Platform note: macOS — use Unix commands, "
+                     "paths under /Users/.")
+    elif os_info["is_linux"]:
+        lines.append("  Platform note: Linux — use Unix commands, "
+                     "paths under /home/.")
+    return "\n".join(lines)
+
+
+def format_tools(tools: dict[str, str]) -> str:
+    """Format the available-tools section of the system prompt.
+
+    Args:
+        tools: dict mapping tool name -> path (from probe_tools)
+
+    Returns:
+        Formatted string listing available tools.
+    """
+    if not tools:
+        return "Available tools: (none detected on PATH)"
+    lines = ["Available tools on PATH:"]
+    for name in sorted(tools):
+        lines.append(f"  - {name}: {tools[name]}")
+    return "\n".join(lines)
+
+
+def format_workspace(paths: dict[str, str]) -> str:
+    """Format the workspace section of the system prompt.
+
+    Args:
+        paths: output of probe_paths()
+
+    Returns:
+        Formatted string describing workspace paths.
+    """
+    lines = [
+        "Workspace:",
+        f"  Working directory: {paths['cwd']}",
+        f"  Home directory: {paths['home']}",
+        f"  Temp directory: {paths['temp']}",
+        f"  Python executable: {paths['python_executable']}",
+        f"  Path separator: '{paths['path_separator']}'",
+    ]
+    return "\n".join(lines)
+
+
+def format_project(project: dict[str, Any]) -> str:
+    """Format the optional project-context section.
+
+    Args:
+        project: output of probe_project()
+
+    Returns:
+        Formatted string, or empty string if no project context.
+    """
+    if not project["is_git_repo"] and not project["project_files"]:
+        return ""
+    lines = ["Project context:"]
+    if project["is_git_repo"]:
+        branch = project.get("branch", "unknown")
+        lines.append(f"  Git repository: yes (branch: {branch})")
+    else:
+        lines.append("  Git repository: no")
+    if project["project_files"]:
+        lines.append(f"  Project files: {', '.join(project['project_files'])}")
+    return "\n".join(lines)
+
+
+# ── Prompt assembly with cache ───────────────────────────────────────────────
+
+_last_env_key: str | None = None
+_last_prompt: str | None = None
+
+
+def assemble_system_prompt(env: dict[str, Any]) -> str:
+    """Assemble the full system prompt from probed environment data.
+
+    Args:
+        env: output of probe_environment()
+
+    Returns:
+        The assembled system prompt as a single string.
+    """
+    sections = [
+        IDENTITY,
+        format_environment(env["os"], env["user_shell"]),
+        format_tools(env["tools"]),
+        format_workspace(env["paths"]),
+        SAFETY_CONSTRAINTS,
+    ]
+    project_section = format_project(env["project"])
+    if project_section:
+        sections.append(project_section)
+    return "\n\n".join(sections)
+
+
+def get_system_prompt(env: dict[str, Any], *, verbose: bool = True) -> str:
+    """Cache wrapper — reassemble only when environment changes.
+
+    Uses json.dumps for deterministic serialization. Python's hash() has
+    process randomization and fails on nested dicts/lists, so it is not
+    suitable for cache keys.
+
+    Args:
+        env: output of probe_environment()
+        verbose: if True, print cache hit/miss diagnostics to stderr
+
+    Returns:
+        The assembled system prompt (cached if env unchanged).
+    """
+    global _last_env_key, _last_prompt
+    key = json.dumps(env, sort_keys=True, ensure_ascii=False, default=str)
+    if key == _last_env_key and _last_prompt:
+        if verbose:
+            print("[cache hit] system prompt unchanged", file=sys.stderr)
+        return _last_prompt
+    _last_env_key = key
+    _last_prompt = assemble_system_prompt(env)
+    if verbose:
+        loaded = ["identity", "environment", "tools", "workspace", "safety"]
+        if format_project(env["project"]):
+            loaded.append("project")
+        print(f"[assembled] sections: {', '.join(loaded)}", file=sys.stderr)
+    return _last_prompt
+
+
+# ── CLI ──────────────────────────────────────────────────────────────────────
+
+def main() -> int:
+    """Entry point — parse args, probe env, print assembled prompt.
+
+    Returns:
+        Exit code (0 on success).
+    """
+    parser = argparse.ArgumentParser(
+        description="Assemble a system prompt from the real runtime environment."
+    )
+    parser.add_argument(
+        "--json", action="store_true",
+        help="Emit the probed environment as JSON instead of the prompt.",
+    )
+    parser.add_argument(
+        "--raw", action="store_true",
+        help="Print only the prompt, no section labels or diagnostics.",
+    )
+    parser.add_argument(
+        "--show-env", action="store_true",
+        help="Print each probed environment fact before the prompt.",
+    )
+    args = parser.parse_args()
+
+    env = probe_environment()
+
+    if args.json:
+        print(json.dumps(env, indent=2, ensure_ascii=False, default=str))
+        return 0
+
+    if args.show_env:
+        print("=== Probed Environment ===")
+        print(f"OS:         {env['os']['system']} {env['os']['release']} "
+              f"({env['os']['machine']})")
+        print(f"Python:     {env['os']['python_version']} "
+              f"({env['os']['python_implementation']})")
+        print(f"User:       {env['user_shell']['user']}@{env['user_shell']['hostname']}")
+        print(f"Shell:      {env['user_shell']['shell']}")
+        print(f"CWD:        {env['paths']['cwd']}")
+        print(f"Home:       {env['paths']['home']}")
+        print(f"Temp:       {env['paths']['temp']}")
+        print(f"Python exe: {env['paths']['python_executable']}")
+        print(f"Tools:      {', '.join(sorted(env['tools'])) or '(none)'}")
+        if env["project"]["is_git_repo"]:
+            print(f"Git branch: {env['project'].get('branch', 'unknown')}")
+        print()
+
+    prompt = get_system_prompt(env, verbose=not args.raw)
+
+    if args.raw:
+        print(prompt)
+    else:
+        print("=== Assembled System Prompt ===")
+        print()
+        print("```")
+        print(prompt)
+        print("```")
+        print()
+        print(f"Prompt length: {len(prompt)} characters")
+
+    # Demonstrate cache: second call with same env should hit cache
+    if not args.raw and not args.json:
+        print()
+        print("=== Cache demonstration (second call) ===")
+        get_system_prompt(env)
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/s17_autonomous_agents/code.py
+++ b/s17_autonomous_agents/code.py
@@ -301,14 +301,14 @@ def scan_unclaimed_tasks() -> list[dict]:
     return unclaimed
 
 
-def idle_poll(agent_name: str, messages: list,
-              name: str, role: str) -> str:
+def idle_poll(name: str, messages: list,
+              role: str) -> str:
     """Poll for 60s. Return 'work', 'shutdown', or 'timeout'."""
     for _ in range(IDLE_TIMEOUT // IDLE_POLL_INTERVAL):
         time.sleep(IDLE_POLL_INTERVAL)
 
         # Check inbox — dispatch protocol messages first
-        inbox = BUS.read_inbox(agent_name)
+        inbox = BUS.read_inbox(name)
         if inbox:
             # Check for shutdown_request
             for msg in inbox:
@@ -331,7 +331,7 @@ def idle_poll(agent_name: str, messages: list,
         unclaimed = scan_unclaimed_tasks()
         if unclaimed:
             task = unclaimed[0]
-            result = claim_task(task["id"], agent_name)
+            result = claim_task(task["id"], name)
             if "Claimed" in result:
                 messages.append({"role": "user",
                     "content": f"<auto-claimed>Task {task['id']}: "
@@ -498,7 +498,7 @@ def spawn_teammate_thread(name: str, role: str, prompt: str) -> str:
                 break
 
             # IDLE phase (s17 new)
-            idle_result = idle_poll(name, messages, name, role)
+            idle_result = idle_poll(name, messages, role)
             if idle_result == "shutdown":
                 break
             if idle_result == "timeout":


### PR DESCRIPTION
移除 idle_poll 冗余参数 agent_name，统一使用 name 标识 teammate。
函数签名由四参改为三参，调用处同步更新。
Closes #374