### PR TITLE
fix(s11): send shutdown_response before teammate exit (#175)

### DIFF
--- a/agents/s11_autonomous_agents.py
+++ b/agents/s11_autonomous_agents.py
@@ -228,6 +228,14 @@ class TeammateManager:
                 inbox = BUS.read_inbox(name)
                 for msg in inbox:
                     if msg.get("type") == "shutdown_request":
+                        req_id = msg.get("request_id", "")
+                        with _tracker_lock:
+                            if req_id in shutdown_requests:
+                                shutdown_requests[req_id]["status"] = "approved"
+                        BUS.send(
+                            name, "lead", "",
+                            "shutdown_response", {"request_id": req_id, "approve": True},
+                        )
                         self._set_status(name, "shutdown")
                         return
                     messages.append({"role": "user", "content": json.dumps(msg)})
@@ -274,6 +282,14 @@ class TeammateManager:
                 if inbox:
                     for msg in inbox:
                         if msg.get("type") == "shutdown_request":
+                            req_id = msg.get("request_id", "")
+                            with _tracker_lock:
+                                if req_id in shutdown_requests:
+                                    shutdown_requests[req_id]["status"] = "approved"
+                            BUS.send(
+                                name, "lead", "",
+                                "shutdown_response", {"request_id": req_id, "approve": True},
+                            )
                             self._set_status(name, "shutdown")
                             return
                         messages.append({"role": "user", "content": json.dumps(msg)})


### PR DESCRIPTION
Teammate _loop 收到 shutdown_request 后直接 return，lead 永远收不到确认。两处退出分支（WORK PHASE L230 / IDLE PHASE L276）均在 return 前调用 BUS.send 回送 shutdown_response 并更新 shutdown_requests 状态。Closes #175