### PR TITLE
fix(s08): drain background notifications before agent_loop exit (#46)

### DIFF
--- a/agents/s08_background_tasks.py
+++ b/agents/s08_background_tasks.py
@@ -200,6 +200,13 @@ def agent_loop(messages: list):
         )
         messages.append({"role": "assistant", "content": response.content})
         if response.stop_reason != "tool_use":
+            notifs = BG.drain_notifications()
+            if notifs:
+                notif_text = "\n".join(
+                    f"[bg:{n['task_id']}] {n['status']}: {n['result']}" for n in notifs
+                )
+                messages.append({"role": "user", "content": f"<background-results>\n{notif_text}\n</background-results>"})
+                continue
             return
         results = []
         for block in response.content:


### PR DESCRIPTION
agent_loop 在 stop_reason != tool_use 时直接 return，_notification_queue 中未投递的后台任务结果永久丢失。退出前再 drain 一次，非空则注入 <background-results> 消息并 continue，仅当队列空且无工具调用时才真正退出。Closes #46