### PR TITLE
fix(s03): block workspace escape via run_bash (#187)

### DIFF
--- a/s03_permission/code.py
+++ b/s03_permission/code.py
@@ -50,7 +50,7 @@ WORKDIR = Path.cwd()
 client = Anthropic(base_url=os.getenv("ANTHROPIC_BASE_URL"))
 MODEL = os.environ["MODEL_ID"]
 
-SYSTEM = f"You are a coding agent at {WORKDIR}. All destructive operations require user approval."
+SYSTEM = f"You are a coding agent at {WORKDIR}. All destructive operations require user approval. You must only access files inside {WORKDIR}. Do not read or modify files outside the workspace."
 
 
 # ═══════════════════════════════════════════════════════════
@@ -64,7 +64,30 @@ def safe_path(p: str) -> Path:
     return path
 
 
+_DANGEROUS_PATTERNS = [
+    "rm -rf /", "sudo", "shutdown", "reboot", "> /dev/",
+    "cat /etc/", "/etc/passwd", "/etc/shadow",
+    "cd / ", "cd ..", "../..",
+]
+
+
+def _escapes_workspace(command: str) -> bool:
+    """Detect commands that access paths outside WORKDIR."""
+    import re
+    for pattern in _DANGEROUS_PATTERNS:
+        if pattern in command:
+            return True
+    abs_paths = re.findall(r'(?:^|\s)(/[^\s]+)', command)
+    workdir_str = str(WORKDIR)
+    for ap in abs_paths:
+        if not ap.startswith(workdir_str):
+            return True
+    return False
+
+
 def run_bash(command: str) -> str:
+    if _escapes_workspace(command):
+        return "Error: Command blocked: escapes workspace"
     try:
         r = subprocess.run(command, shell=True, cwd=WORKDIR,
                            capture_output=True, text=True, timeout=120)


### PR DESCRIPTION
run_bash 无任何路径约束，run_read 被 safe_path 拦截后 LLM 可用 bash 绕过读取工作目录外文件。新增 _escapes_workspace() 检测危险命令模式 + 绝对路径逃逸，SYSTEM 提示词声明工作目录边界。Closes #187