### PR TITLE
fix(s10): enforce plan_approval gate before major work (#173)

### DIFF
--- a/agents/s10_team_protocols.py
+++ b/agents/s10_team_protocols.py
@@ -220,6 +220,15 @@ class TeammateManager:
             self._save_config()
 
     def _exec(self, sender: str, tool_name: str, args: dict) -> str:
+        # Gate major work tools behind plan approval
+        if tool_name in ("bash", "write_file", "edit_file"):
+            with _tracker_lock:
+                has_pending = any(
+                    r["from"] == sender and r["status"] == "pending"
+                    for r in plan_requests.values()
+                )
+            if has_pending:
+                return "Error: Plan submitted but not yet approved. Wait for lead approval before executing major work."
         # these base tools are unchanged from s02
         if tool_name == "bash":
             return _run_bash(args["command"])


### PR DESCRIPTION
s10 _exec 对 bash/write_file/edit_file 无 plan 状态门控，teammate 可绕过 plan_approval 直接执行 major work。新增 _plan_approved 检查，有 pending plan 时拒绝执行并提示等待审批。Closes #173