### PR TITLE
fix(s06): preserve write_file/edit_file results in micro_compact (#274)

### DIFF
--- a/agents/s06_context_compact.py
+++ b/agents/s06_context_compact.py
@@ -57,7 +57,7 @@ SYSTEM = f"You are a coding agent at {WORKDIR}. Use tools to solve tasks."
 THRESHOLD = 50000
 TRANSCRIPT_DIR = WORKDIR / ".transcripts"
 KEEP_RECENT = 3
-PRESERVE_RESULT_TOOLS = {"read_file"}
+PRESERVE_RESULT_TOOLS = {"read_file", "write_file", "edit_file"}
 
 
 def estimate_tokens(messages: list) -> int:


### PR DESCRIPTION
micro_compact 仅保留 read_file 结果，write_file/edit_file 等状态变更结果被压缩为占位符。扩展 PRESERVE_RESULT_TOOLS 为 {read_file, write_file, edit_file}。Closes #274