### PR TITLE
feat(s10): add build_system_reminder for dynamic context injection (#279)

### DIFF
--- a/s10_system_prompt/code.py
+++ b/s10_system_prompt/code.py
@@ -167,6 +167,21 @@ def update_context(context: dict, messages: list) -> dict:
     }
 
 
+def build_system_reminder(context: dict) -> str:
+    """Build a dynamic reminder injected after tool results.
+
+    Reflects current context: memory status, tool availability, workspace.
+    """
+    reminders = []
+    if context.get("memories"):
+        reminders.append(f"Memory loaded ({len(context['memories'])} chars).")
+    else:
+        reminders.append("No memory file found. Use write_file to create .memory/MEMORY.md.")
+    reminders.append(f"Tools available: {', '.join(context.get('enabled_tools', []))}.")
+    reminders.append(f"Workspace: {context.get('workspace', 'unknown')}.")
+    return "\n".join(reminders)
+
+
 # ── Agent Loop ──
 
 def agent_loop(messages: list, context: dict):
@@ -191,6 +206,10 @@ def agent_loop(messages: list, context: dict):
             results.append({"type": "tool_result",
                             "tool_use_id": block.id, "content": output})
         messages.append({"role": "user", "content": results})
+
+        # Inject dynamic system reminder after tool results
+        reminder = build_system_reminder(context)
+        messages.append({"role": "user", "content": f"<system-reminder>\n{reminder}\n</system-reminder>"})
 
         # Re-evaluate context and prompt after each tool round
         context = update_context(context, messages)


### PR DESCRIPTION
s10 code.py 中 build_system_reminder 函数不存在，agent_loop 无动态提醒注入。新增 build_system_reminder(context) 函数，在 tool_result 后注入 <system-reminder> 消息，反映 memory 状态、工具可用性、工作目录。Closes #279