### PR TITLE
fix(s01): cross-platform shell support for Windows (#65)

### DIFF
--- a/agents/s01_agent_loop.py
+++ b/agents/s01_agent_loop.py
@@ -25,6 +25,7 @@ policy, hooks, and lifecycle controls on top.
 """
 
 import os
+import platform
 import subprocess
 
 try:
@@ -63,12 +64,17 @@ TOOLS = [{
 
 
 def run_bash(command: str) -> str:
-    dangerous = ["rm -rf /", "sudo", "shutdown", "reboot", "> /dev/"]
+    dangerous = ["rm -rf /", "sudo", "shutdown", "reboot", "> /dev/",
+                 "format ", "del /f", "rmdir /s", "reg delete"]
     if any(d in command for d in dangerous):
         return "Error: Dangerous command blocked"
     try:
-        r = subprocess.run(command, shell=True, cwd=os.getcwd(),
-                           capture_output=True, text=True, timeout=120)
+        if platform.system() == "Windows":
+            r = subprocess.run(["powershell", "-NoProfile", "-Command", command],
+                               cwd=os.getcwd(), capture_output=True, text=True, timeout=120)
+        else:
+            r = subprocess.run(command, shell=True, cwd=os.getcwd(),
+                               capture_output=True, text=True, timeout=120)
         out = (r.stdout + r.stderr).strip()
         return out[:50000] if out else "(no output)"
     except subprocess.TimeoutExpired:

--- a/s01_agent_loop/code.py
+++ b/s01_agent_loop/code.py
@@ -28,6 +28,7 @@ Usage:
 """
 
 import os
+import platform
 import subprocess
 
 try:
@@ -67,12 +68,17 @@ TOOLS = [{
 
 # ── Tool execution ────────────────────────────────────────
 def run_bash(command: str) -> str:
-    dangerous = ["rm -rf /", "sudo", "shutdown", "reboot", "> /dev/"]
+    dangerous = ["rm -rf /", "sudo", "shutdown", "reboot", "> /dev/",
+                 "format ", "del /f", "rmdir /s", "reg delete"]
     if any(d in command for d in dangerous):
         return "Error: Dangerous command blocked"
     try:
-        r = subprocess.run(command, shell=True, cwd=os.getcwd(),
-                           capture_output=True, text=True, timeout=120)
+        if platform.system() == "Windows":
+            r = subprocess.run(["powershell", "-NoProfile", "-Command", command],
+                               cwd=os.getcwd(), capture_output=True, text=True, timeout=120)
+        else:
+            r = subprocess.run(command, shell=True, cwd=os.getcwd(),
+                               capture_output=True, text=True, timeout=120)
         out = (r.stdout + r.stderr).strip()
         return out[:50000] if out else "(no output)"
     except subprocess.TimeoutExpired:


### PR DESCRIPTION
shell=True 在 Windows 调用 cmd.exe，Unix 命令（ls/cat/grep/管道）全部失败。新增 platform.system() 检测，Windows 下使用 powershell -NoProfile -Command，黑名单添加 format/del/rmdir/reg delete 等 Windows 危险命令。Closes #65