### PR TITLE
fix(s16): correct tool names and storage structure in overview SVG (#373)

### DIFF
--- a/s16_team_protocols/images/team-protocols-overview.svg
+++ b/s16_team_protocols/images/team-protocols-overview.svg
@@ -57,7 +57,7 @@
   <rect x="378" y="80" width="356" height="60" rx="8" fill="#f0f4ff" stroke="#2563eb" stroke-width="1.5"/>
   <text x="556" y="98" fill="#1e3a5f" font-size="10" font-weight="600" text-anchor="middle">TOOL DISPATCH（核心工具集）</text>
   <text x="394" y="114" fill="#2563eb" font-size="8">bash · read · write · task(4) · spawn · send · inbox</text>
-  <text x="394" y="128" fill="#7c3aed" font-size="8" font-weight="700">★ request_shutdown · request_plan · review_plan</text>
+  <text x="394" y="128" fill="#7c3aed" font-size="8" font-weight="700">★ shutdown_request · plan_approval</text>
 
   <!-- Loop back -->
   <path d="M 734 110 L 748 110 L 748 150 L 55 150 L 55 130" fill="none" stroke="#94a3b8" stroke-width="1" marker-end="url(#arrow)" stroke-dasharray="5,4"/>
@@ -69,8 +69,8 @@
   <!-- Step 1: Send request -->
   <rect x="50" y="208" width="130" height="52" rx="6" fill="#fff" stroke="#7c3aed" stroke-width="1"/>
   <text x="115" y="226" fill="#7c3aed" font-size="9" font-weight="600" text-anchor="middle">① Lead 发请求</text>
-  <text x="115" y="240" fill="#6b7280" font-size="7" text-anchor="middle">BUS.send("shutdown_request"</text>
-  <text x="115" y="252" fill="#6b7280" font-size="7" text-anchor="middle">metadata={request_id})</text>
+  <text x="115" y="240" fill="#6b7280" font-size="7" text-anchor="middle">handle_shutdown_request(teammate)</text>
+  <text x="115" y="252" fill="#6b7280" font-size="7" text-anchor="middle">→ BUS.send(shutdown_request)</text>
 
   <line x1="180" y1="234" x2="206" y2="234" stroke="#7c3aed" stroke-width="1.5" marker-end="url(#arrow-purple)"/>
 
@@ -124,8 +124,8 @@
   <!-- pending_requests storage -->
   <rect x="400" y="296" width="330" height="85" rx="8" fill="#f5f3ff" stroke="#7c3aed" stroke-width="1.5"/>
   <text x="565" y="316" fill="#4c1d95" font-size="10" font-weight="700" text-anchor="middle">pending_requests 存储</text>
-  <text x="420" y="336" fill="#7c3aed" font-size="9">pending_requests: dict[str, ProtocolState]</text>
-  <text x="420" y="352" fill="#6b7280" font-size="8">request_id → {type, sender, status, created_at}</text>
+  <text x="420" y="336" fill="#7c3aed" font-size="9">shutdown_requests: dict  +  plan_requests: dict</text>
+  <text x="420" y="352" fill="#6b7280" font-size="8">req_id → {target/from, status}  (no ProtocolState)</text>
   <text x="420" y="368" fill="#6b7280" font-size="8">match_response: 按 request_id 找回对应请求</text>
 
   <!-- ===== Row 4: Two protocols use same machine ===== -->
@@ -135,7 +135,7 @@
   <text x="295" y="419" fill="#92400e" font-size="9" text-anchor="middle">shutdown_request</text>
   <text x="368" y="419" fill="#475569" font-size="10">和</text>
   <rect x="390" y="406" width="140" height="18" rx="4" fill="#dbeafe" stroke="#2563eb" stroke-width="1"/>
-  <text x="460" y="419" fill="#1e40af" font-size="9" text-anchor="middle">plan_approval_request</text>
+  <text x="460" y="419" fill="#1e40af" font-size="9" text-anchor="middle">plan_approval</text>
   <text x="540" y="419" fill="#475569" font-size="10">共用 pending→approved/rejected 状态机</text>
   <text x="55" y="436" fill="#6b7280" font-size="8">新增协议类型 = 新的 msg_type，不需要新状态机。request_id 关联请求和响应。</text>
 


### PR DESCRIPTION
SVG 工具名错误（request_shutdown→shutdown_request, request_plan/review_plan→plan_approval），存储结构错误（统一 ProtocolState→双字典），流程描述与代码不符。修正工具名、存储结构为 shutdown_requests+plan_requests 双字典，删除不存在的 ProtocolState/created_at。Closes #373