### PR TITLE
docs(skills): add origin note to agent-philosophy.md (#380)

### DIFF
--- a/skills/agent-builder/references/agent-philosophy.md
+++ b/skills/agent-builder/references/agent-philosophy.md
@@ -1,3 +1,5 @@
+<!-- Source: Original content from shareAI-lab/learn-claude-code (s01-s12 harness engineering series). Licensed under the project's license. See repository for full context. -->
+
 # The Philosophy of Agent Harness Engineering
 
 > **The model already knows how to be an agent. Your job is to build it a world worth acting in.**


### PR DESCRIPTION
agent-philosophy.md 全文无任何来源标注，读者无法判断是原创还是引用。文件头部添加 HTML 注释标注来源为 shareAI-lab/learn-claude-code 仓库原创内容（s01-s12 harness engineering 系列）。Closes #380