### PR TITLE
fix(s09): wait for active teammates before lead exit (#291)

### DIFF
--- a/agents/s09_agent_teams.py
+++ b/agents/s09_agent_teams.py
@@ -359,6 +359,13 @@ def agent_loop(messages: list):
         )
         messages.append({"role": "assistant", "content": response.content})
         if response.stop_reason != "tool_use":
+            # Wait for active teammates before exiting
+            import time
+            for _ in range(120):  # 120 seconds timeout
+                active = [m for m in TEAM.config["members"] if m["status"] == "working"]
+                if not active:
+                    break
+                time.sleep(1)
             return
         results = []
         for block in response.content:


### PR DESCRIPTION
lead agent_loop 在 end_turn 时直接 return，不等待 active teammate 完成。退出前轮询 TEAM.config 中 status==working 的成员，最多等待 120 秒。Closes #291