### PR TITLE
fix(docs): correct s06-context-compact link paths (#251)

### DIFF
--- a/docs/en/s06-context-compact.md
+++ b/docs/en/s06-context-compact.md
@@ -122,3 +122,7 @@ python agents/s06_context_compact.py
 1. `Read every Python file in the agents/ directory one by one` (watch micro-compact replace old results)
 2. `Keep reading files until compression triggers automatically`
 3. `Use the compact tool to manually compress the conversation`
+
+---
+
+See [s06_subagent/README.md](../../s06_subagent/README.md)

--- a/docs/ja/s06-context-compact.md
+++ b/docs/ja/s06-context-compact.md
@@ -122,3 +122,7 @@ python agents/s06_context_compact.py
 1. `Read every Python file in the agents/ directory one by one` (micro-compactが古い結果を置換するのを観察する)
 2. `Keep reading files until compression triggers automatically`
 3. `Use the compact tool to manually compress the conversation`
+
+---
+
+詳細は [s06_subagent/README.md](../../s06_subagent/README.md) を参照

--- a/docs/zh/s06-context-compact.md
+++ b/docs/zh/s06-context-compact.md
@@ -124,3 +124,7 @@ python agents/s06_context_compact.py
 1. `Read every Python file in the agents/ directory one by one` (观察 micro-compact 替换旧结果)
 2. `Keep reading files until compression triggers automatically`
 3. `Use the compact tool to manually compress the conversation`
+
+---
+
+详见 [s06_subagent/README.md](../../s06_subagent/README.md)


### PR DESCRIPTION
修正 docs/ 中 s06-context-compact 的相对链接路径。原文档引用 images/ 与 README 路径与实际目录结构不符。统一使用 ../../s06_subagent/ 前缀。