### PR TITLE
docs: add API compatibility note for tools format (#370)

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,6 +330,18 @@ flowchart TD
 
 ---
 
+## API 兼容性说明
+
+本仓库的 agent 代码使用 **Anthropic 原生 API** 的 `tools` 字段格式（`input_schema`）。如果使用 OpenAI 兼容格式的第三方中转 API（如 `function` 类型），需要自行转换：
+
+| Anthropic 原生 | OpenAI 兼容 |
+|----------------|-------------|
+| `{"name": "bash", "input_schema": {...}}` | `{"type": "function", "function": {"name": "bash", "parameters": {...}}}` |
+
+推荐直接使用 Anthropic API 或兼容原生格式的中转服务。
+
+---
+
 ## How to Read
 
 Each chapter is a folder. Open one and you will find:


### PR DESCRIPTION
README 新增 API 兼容性说明，明确 tools 字段仅支持 Anthropic 原生 input_schema 格式。OpenAI 兼容 API（function calling）需自行转换。避免用户使用第三方中转 API 时遇到 400 错误。