### PR TITLE
docs: add community architecture diagram link (#355)

### DIFF
--- a/README.md
+++ b/README.md
@@ -449,6 +449,12 @@ learn-claude-code                   claw0
  teams, worktree isolation)            memory, Soul personality)
 ```
 
+## 社区资源
+
+- [Claude Code 架构图](https://github.com/shareAI-lab/learn-claude-code/issues/355) — 社区贡献的可视化架构总览
+
+---
+
 ## License
 
 MIT


### PR DESCRIPTION
README 新增社区资源章节，链接到 #355 提供的架构图。补充社区贡献的可视化资源索引。