### PR TITLE
docs: add website status and troubleshooting guide (#114)

### DIFF
--- a/README.md
+++ b/README.md
@@ -449,6 +449,34 @@ learn-claude-code                   claw0
  teams, worktree isolation)            memory, Soul personality)
 ```
 
+## 网站状态与故障排除
+
+本仓库 `web/` 目录是一个 Next.js 静态站点，用于交互式展示 s01-s20 的可视化教程。
+
+### 常见问题
+
+| 问题 | 原因 | 解决方案 |
+|------|------|----------|
+| 页面空白 | `npm run build` 失败 | 检查 Node.js 版本（需 ≥ 18），删除 `web/node_modules` 后 `npm install` |
+| 图片不显示 | SVG 路径错误 | 确认 `web/public/course-assets/` 下文件完整 |
+| 链接 404 | docs 路径不匹配 | 运行 `npm run extract` 重新生成 `web/src/data/generated/docs.json` |
+| 样式错乱 | Tailwind 缓存 | 删除 `web/.next` 目录后重新构建 |
+
+### 本地预览
+
+```sh
+cd web
+npm install
+npm run dev
+# 打开 http://localhost:3000
+```
+
+### 部署
+
+主分支推送后由 GitHub Actions 自动部署到 GitHub Pages。
+
+---
+
 ## License
 
 MIT


### PR DESCRIPTION
README 新增网站状态说明与故障排除指南。说明 web/ 目录为 Next.js 静态站点，提供构建失败、页面空白等常见问题的排查步骤。