### PR TITLE
[codex] Update provider model examples

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,51 +11,60 @@ MODEL_ID=claude-sonnet-4-6
 # =============================================================================
 #  Anthropic-compatible providers
 #
-#  Provider         MODEL_ID              SWE-bench  TB2     Base URL
-#  ---------------  --------------------  ---------  ------  -------------------
-#  Anthropic        claude-sonnet-4-6     79.6%      59.1%   (default)
-#  MiniMax          MiniMax-M2.5          80.2%        -     see below
-#  GLM (Zhipu)      glm-5                77.8%        -     see below
-#  Kimi (Moonshot)  kimi-k2.5            76.8%        -     see below
-#  DeepSeek         deepseek-chat        73.0%        -     see below
-#                   (V3.2)
+#  Provider         MODEL_ID                    Notes                 Base URL
+#  ---------------  --------------------------  --------------------  -------------------
+#  Anthropic        claude-sonnet-4-6           default               (default)
+#  MiniMax          MiniMax-M3                  latest M-series       see below
+#  GLM (Zhipu)      glm-5.2                     latest coding model   see below
+#  Kimi (Moonshot)  kimi-k2.7-code              coding model          see below
+#  DeepSeek         deepseek-v4-pro             pro model             see below
+#                   deepseek-v4-flash           flash model           see below
 #
-#  SWE-bench = SWE-bench Verified (Feb 2026)
-#  TB2       = Terminal-Bench 2.0 (Feb 2026)
+#  Check provider docs for current availability, pricing, and regional access.
 # =============================================================================
 
 # ---- International ----
 
 # MiniMax          https://www.minimax.io
 # ANTHROPIC_BASE_URL=https://api.minimax.io/anthropic
-# MODEL_ID=MiniMax-M2.5
+# MODEL_ID=MiniMax-M3
+# MODEL_ID=MiniMax-M2.7
+# MODEL_ID=MiniMax-M2.7-highspeed
 
 # GLM (Zhipu)      https://z.ai
 # ANTHROPIC_BASE_URL=https://api.z.ai/api/anthropic
-# MODEL_ID=glm-5
+# MODEL_ID=glm-5.2
 
-# Kimi (Moonshot)  https://platform.moonshot.ai
+# Kimi (Moonshot)  https://platform.kimi.ai
 # ANTHROPIC_BASE_URL=https://api.moonshot.ai/anthropic
-# MODEL_ID=kimi-k2.5
+# MODEL_ID=kimi-k2.7-code
+# MODEL_ID=kimi-k2.7-code-highspeed
+# MODEL_ID=kimi-k2.6
 
 # DeepSeek         https://platform.deepseek.com
 # ANTHROPIC_BASE_URL=https://api.deepseek.com/anthropic
-# MODEL_ID=deepseek-chat
+# MODEL_ID=deepseek-v4-pro
+# MODEL_ID=deepseek-v4-flash
 
 # ---- China mainland ----
 
 # MiniMax          https://platform.minimax.io
 # ANTHROPIC_BASE_URL=https://api.minimaxi.com/anthropic
-# MODEL_ID=MiniMax-M2.5
+# MODEL_ID=MiniMax-M3
+# MODEL_ID=MiniMax-M2.7
+# MODEL_ID=MiniMax-M2.7-highspeed
 
 # GLM (Zhipu)      https://open.bigmodel.cn
 # ANTHROPIC_BASE_URL=https://open.bigmodel.cn/api/anthropic
-# MODEL_ID=glm-5
+# MODEL_ID=glm-5.2
 
 # Kimi (Moonshot)  https://platform.moonshot.cn
 # ANTHROPIC_BASE_URL=https://api.moonshot.cn/anthropic
-# MODEL_ID=kimi-k2.5
+# MODEL_ID=kimi-k2.7-code
+# MODEL_ID=kimi-k2.7-code-highspeed
+# MODEL_ID=kimi-k2.6
 
 # DeepSeek (no regional split, same endpoint globally)
 # ANTHROPIC_BASE_URL=https://api.deepseek.com/anthropic
-# MODEL_ID=deepseek-chat
+# MODEL_ID=deepseek-v4-pro
+# MODEL_ID=deepseek-v4-flash


### PR DESCRIPTION
## Summary

Refresh the Anthropic-compatible provider model examples in `.env.example`.

## Changes

- Update MiniMax examples from `MiniMax-M2.5` to `MiniMax-M3`, with `MiniMax-M2.7` and `MiniMax-M2.7-highspeed` as alternatives
- Update GLM examples from `glm-5` to `glm-5.2`
- Update Kimi examples from `kimi-k2.5` to `kimi-k2.7-code`, with high-speed and K2.6 alternatives
- Update DeepSeek examples from the legacy `deepseek-chat` alias to `deepseek-v4-pro` and `deepseek-v4-flash`
- Replace stale benchmark columns with a docs-check reminder, since provider model recommendations change more frequently than the endpoint examples

## References

- MiniMax Anthropic-compatible API: https://platform.minimax.io/docs/api-reference/text-anthropic-api
- Z.AI GLM-5.2 docs: https://docs.z.ai/guides/llm/glm-5.2
- Kimi Claude Code setup and model list: https://platform.kimi.ai/docs/guide/agent-support, https://platform.kimi.ai/docs/models
- DeepSeek quick start and Anthropic API docs: https://api-docs.deepseek.com/, https://api-docs.deepseek.com/guides/anthropic_api

## Validation

- `git diff --check -- .env.example`
