### PR TITLE
[codex] Restore s06 todo planning guidance

### DIFF
--- a/s06_subagent/code.py
+++ b/s06_subagent/code.py
@@ -51,6 +51,8 @@ CURRENT_TODOS: list[dict] = []
 
 SYSTEM = (
     f"You are a coding agent at {WORKDIR}. "
+    "Before starting any multi-step task, use todo_write to plan your steps. "
+    "Update status as you go. "
     "For complex sub-problems, use the task tool to spawn a subagent."
 )
 


### PR DESCRIPTION
## Summary
- restore the s05 todo planning guidance in the s06 main system prompt
- keep the s06 subagent guidance so both behaviors are active

## Why
s06 keeps the todo_write tool and nag reminder from s05, but its main SYSTEM prompt only mentioned subagents. That made the inherited todo behavior less discoverable and inconsistent with the s05 progression.

## Validation
- python3 -m py_compile s06_subagent/code.py
- python3 -m pytest tests/test_todo_write_string_input.py (not run: pytest is not installed in the current Python environment)