### PR TITLE
fix(s09_memory): align consolidation cap with trigger threshold

### DIFF
--- a/s09_memory/code.py
+++ b/s09_memory/code.py
@@ -299,7 +299,7 @@ def consolidate_memories():
         "Consolidate the following memory files. Rules:\n"
         "1. Merge duplicates into one\n"
         "2. Remove outdated/contradicted memories\n"
-        "3. Keep the total under 30 memories\n"
+        "3. Keep the total under 8 memories\n"
         "4. Preserve important user preferences above all\n"
         "Return a JSON array. Each item: {name, type, description, body}.\n\n"
         f"{catalog[:16000]}"


### PR DESCRIPTION
## Summary
- `consolidate_memories()` triggers at `CONSOLIDATE_THRESHOLD = 10` files, but its prompt tells the model to keep the total under 30 — since 10 < 30, the cap never forces any actual merging/pruning when consolidation runs.
- Lowered the cap in the prompt to 8 (below the trigger threshold) so each consolidation pass has real room to shrink the memory set.

## Test plan
- [ ] Manually seed `.memory/` with 10 dummy memory files and run the agent loop to confirm `consolidate_memories()` now reduces the count below 10

🤖 Generated with [Claude Code](https://claude.com/claude-code)