### PR TITLE
fix(s03): add 'del' keyword to Gate 2 bash rule for Windows compatibility

### DIFF
--- a/s03_permission/README.en.md
+++ b/s03_permission/README.en.md
@@ -65,7 +65,7 @@ PERMISSION_RULES = [
     },
     {
         "tools": ["bash"],
-        "check": lambda args: any(kw in args.get("command", "") for kw in ["rm ", "> /etc/", "chmod 777"]),
+        "check": lambda args: any(kw in args.get("command", "") for kw in ["rm ", "> /etc/", "chmod 777", "del"]),
         "message": "Potentially destructive command",
     },
 ]

--- a/s03_permission/README.ja.md
+++ b/s03_permission/README.ja.md
@@ -65,7 +65,7 @@ PERMISSION_RULES = [
     },
     {
         "tools": ["bash"],
-        "check": lambda args: any(kw in args.get("command", "") for kw in ["rm ", "> /etc/", "chmod 777"]),
+        "check": lambda args: any(kw in args.get("command", "") for kw in ["rm ", "> /etc/", "chmod 777", "del"]),
         "message": "Potentially destructive command",
     },
 ]

--- a/s03_permission/README.md
+++ b/s03_permission/README.md
@@ -65,7 +65,7 @@ PERMISSION_RULES = [
     },
     {
         "tools": ["bash"],
-        "check": lambda args: any(kw in args.get("command", "") for kw in ["rm ", "> /etc/", "chmod 777"]),
+        "check": lambda args: any(kw in args.get("command", "") for kw in ["rm ", "> /etc/", "chmod 777", "del"]),
         "message": "Potentially destructive command",
     },
 ]

--- a/s03_permission/code.py
+++ b/s03_permission/code.py
@@ -161,7 +161,7 @@ PERMISSION_RULES = [
      "check": lambda args: not (WORKDIR / args.get("path", "")).resolve().is_relative_to(WORKDIR),
      "message": "Writing outside workspace"},
     {"tools": ["bash"],
-     "check": lambda args: any(kw in args.get("command", "") for kw in ["rm ", "> /etc/", "chmod 777"]),
+     "check": lambda args: any(kw in args.get("command", "") for kw in ["rm ", "> /etc/", "chmod 777", "del"]),
      "message": "Potentially destructive command"},
 ]
 


### PR DESCRIPTION
## 变更说明

在 `s03_permission` 的闸门 2（Gate 2）中，bash 工具的破坏性命令检查关键词列表中添加了 `"del"`。

### 原因

Windows 原生删除命令为 `del`（等价于 Linux/macOS 的 `rm`），原关键词列表只包含 `["rm ", "> /etc/", "chmod 777"]`，导致 Windows 平台上执行 `Delete the file test.txt` 时，模型生成 `del test.txt` 命令绕过权限检查，文件被直接删除，无用户确认。

### 复现环境

- 操作系统：Windows
- 运行命令：`python s03_permission/code.py`
- 模型：`mimo-v2.5-pro`（mimo token plan）
- 测试 prompt：`Delete the file test.txt`

## 关联 Issue

Closes #448

## 改动范围

- [x] `s03_permission/code.py` — 在 Gate 2 bash 规则的关键词列表中添加 `"del"`
- [x] `s03_permission/README.md`（中文）— 同步代码块
- [x] `s03_permission/README.en.md`（英文）— 同步代码块
- [x] `s03_permission/README.ja.md`（日文）— 同步代码块

## AI 声明

本 PR 借助 AI 辅助生成，我已阅读并认可所有改动。
