### PR TITLE
avoid Python code module conflict in s01

### DIFF
--- a/s01_agent_loop/code.py
+++ b/s01_agent_loop/code.py
@@ -93,7 +93,7 @@ def agent_loop(messages: list):
         messages.append({"role": "assistant", "content": response.content})
 
         # If the model didn't call a tool, we're done
-        if response.stop_reason != "tool_use":
+        if response.stop_reason == "end_turn":
             return
 
         # Execute each tool call, collect results


### PR DESCRIPTION
## Summary

Update the S01 agent loop to terminate explicitly when the model returns
`stop_reason == "end_turn"`.

## Motivation
之前的条件会将除 `tool_use` 之外的所有响应都视为当前轮次已经完成，显式判断 end_turn 可以更清楚地表达
The previous condition treated every response other than `tool_use` as a
completed turn:

```python
if response.stop_reason != "tool_use":
    return