### PR TITLE
fix: reset rounds_since_todo on each session

### DIFF
--- a/s05_todo_write/code.py
+++ b/s05_todo_write/code.py
@@ -236,6 +236,7 @@ rounds_since_todo = 0
 
 def agent_loop(messages: list):
     global rounds_since_todo
+    rounds_since_todo = 0  # 每轮新对话从0开始计数
     while True:
         # s05: nag reminder — inject if model hasn't updated todos for 3 rounds
         if rounds_since_todo >= 3 and messages:

--- a/s05_todo_write/code.py
+++ b/s05_todo_write/code.py
@@ -232,11 +232,8 @@ register_hook("Stop", summary_hook)
 #  agent_loop — same as s04 + nag reminder counter
 # ═══════════════════════════════════════════════════════════
 
-rounds_since_todo = 0
-
 def agent_loop(messages: list):
-    global rounds_since_todo
-    rounds_since_todo = 0  # 每轮新对话从0开始计数
+    rounds_since_todo = 0
     while True:
         # s05: nag reminder — inject if model hasn't updated todos for 3 rounds
         if rounds_since_todo >= 3 and messages:

--- a/s06_subagent/code.py
+++ b/s06_subagent/code.py
@@ -316,6 +316,7 @@ rounds_since_todo = 0
 
 def agent_loop(messages: list):
     global rounds_since_todo
+    rounds_since_todo = 0  # 每轮新对话从0开始计数
     while True:
         # s05: nag reminder
         if rounds_since_todo >= 3 and messages:

--- a/s06_subagent/code.py
+++ b/s06_subagent/code.py
@@ -312,11 +312,8 @@ register_hook("Stop", summary_hook)
 #  agent_loop — same as s05 + nag reminder, task auto-dispatches
 # ═══════════════════════════════════════════════════════════
 
-rounds_since_todo = 0
-
 def agent_loop(messages: list):
-    global rounds_since_todo
-    rounds_since_todo = 0  # 每轮新对话从0开始计数
+    rounds_since_todo = 0
     while True:
         # s05: nag reminder
         if rounds_since_todo >= 3 and messages:

--- a/s07_skill_loading/code.py
+++ b/s07_skill_loading/code.py
@@ -360,6 +360,7 @@ rounds_since_todo = 0
 
 def agent_loop(messages: list):
     global rounds_since_todo
+    rounds_since_todo = 0  # 每轮新对话从0开始计数
     while True:
         if rounds_since_todo >= 3 and messages:
             messages.append({"role": "user",

--- a/s07_skill_loading/code.py
+++ b/s07_skill_loading/code.py
@@ -356,11 +356,8 @@ register_hook("Stop", summary_hook)
 #  agent_loop — same as s05-s06 + nag reminder
 # ═══════════════════════════════════════════════════════════
 
-rounds_since_todo = 0
-
 def agent_loop(messages: list):
-    global rounds_since_todo
-    rounds_since_todo = 0  # 每轮新对话从0开始计数
+    rounds_since_todo = 0
     while True:
         if rounds_since_todo >= 3 and messages:
             messages.append({"role": "user",


### PR DESCRIPTION
修复 rounds_since_todo 在多次会话之间不会被重置的问题。

改动说明：
- 在 agent_loop 入口处重置计数器
- 确保新会话从 0 开始计数
Fixes #460