### PR TITLE
Fix/resolve lambda default param capturing current_model

### DIFF
--- a/s11_error_recovery/code.py
+++ b/s11_error_recovery/code.py
@@ -272,10 +272,10 @@ def agent_loop(messages: list, context: dict):
         # ── LLM call: with_retry handles 429/529, outer handles rest ──
         try:
             response = with_retry(
-                lambda mt=max_tokens, mdl=state.current_model:
-                    client.messages.create(
-                        model=mdl, system=system, messages=messages,
-                        tools=TOOLS, max_tokens=mt),
+                lambda: client.messages.create(
+                    model=state.current_model, system=system,
+                    messages=messages, tools=TOOLS,
+                    max_tokens=max_tokens),
                 state)
         except Exception as e:
             # Path 2: prompt_too_long -> reactive compact (once)


### PR DESCRIPTION
修复连续 529 触发 fallback 模型切换后(`state.current_model = FALLBACK_MODEL`)，重试仍然使用原始模型。

改动：
  - lambda 改为闭包引用，每次调用时读取 state.current_model
  
  Fixes #460