### PR TITLE
fix(context-compact): fix L1 truncation bug on consecutive tool results

### DIFF
--- a/s08_context_compact/code.py
+++ b/s08_context_compact/code.py
@@ -299,9 +299,9 @@ def snip_compact(messages, max_messages=50):
     if head_end > 0 and _message_has_tool_use(messages[head_end - 1]):
         while head_end < len(messages) and _is_tool_result_message(messages[head_end]):
             head_end += 1
-    if (tail_start > 0 and tail_start < len(messages)
-            and _is_tool_result_message(messages[tail_start])
-            and _message_has_tool_use(messages[tail_start - 1])):
+    while (tail_start > 0 and tail_start < len(messages) and _is_tool_result_message(messages[tail_start])):
+        tail_start -= 1
+    if tail_start > 0 and _message_has_tool_use(messages[tail_start - 1]):
         tail_start -= 1
     if head_end >= tail_start:
         return messages


### PR DESCRIPTION
### Summary
Fixes a hidden context truncation bug in the L1 `snip_compact` pipeline where consecutive `tool_result` messages (often generated by parallel tool execution) would cause a validation failure, leading to broken tool/result pairings and API crashes.

### The Problem
In the original `snip_compact` implementation, the tail boundary alignment (`tail_start`) was guarded by a single `if` statement:
```python
if (tail_start > 0 and tail_start < len(messages)
        and _is_tool_result_message(messages[tail_start])
        and _message_has_tool_use(messages[tail_start - 1])):
    tail_start -= 1