### PR TITLE
fix(s03,s04,s20): resolve Gate2 safe_path conflict — permission dead on write/edit

### DIFF
--- a/s03_permission/README.en.md
+++ b/s03_permission/README.en.md
@@ -28,7 +28,7 @@ The three gates correspond to three decisions:
 | Gate | Purpose | On Match |
 |------|---------|----------|
 | 1. Deny List | Permanently forbidden operations (`rm -rf /`, `sudo`) | Denied immediately, not executed |
-| 2. Rule Matching | Context-dependent operations (writing outside workspace, `rm` files) | Passed to Gate 3 |
+| 2. Rule Matching | Context-dependent operations (reading/writing outside workspace, `rm` files) | Passed to Gate 3 |
 | 3. User Approval | After Gate 2 matches, pauses for user confirmation | User decides allow or deny |
 
 None of the three gates match → execute directly. Most routine operations take this path.
@@ -59,9 +59,9 @@ def check_deny_list(command: str) -> str | None:
 ```python
 PERMISSION_RULES = [
     {
-        "tools": ["write_file", "edit_file"],
+        "tools": ["read_file", "write_file", "edit_file"],
         "check": lambda args: not (WORKDIR / args.get("path", "")).resolve().is_relative_to(WORKDIR),
-        "message": "Writing outside workspace",
+        "message": "Access outside workspace",
     },
     {
         "tools": ["bash"],

--- a/s03_permission/README.ja.md
+++ b/s03_permission/README.ja.md
@@ -28,7 +28,7 @@ s02 のループは完全に維持される。唯一の変更は、ツール実�
 | ゲート | 役割 | 一致時 |
 |--------|------|--------|
 | 1. 拒否リスト | 常に禁止される操作（`rm -rf /`、`sudo`） | 即座に拒否、実行しない |
-| 2. ルールマッチング | コンテキスト依存の操作（作業ディレクトリ外への書き込み、`rm` ファイル） | ゲート 3 へ |
+| 2. ルールマッチング | コンテキスト依存の操作（作業ディレクトリ外への読み書き、`rm` ファイル） | ゲート 3 へ |
 | 3. ユーザー承認 | ゲート 2 が一致した場合、ユーザー確認を待機 | ユーザーが許可または拒否を決定 |
 
 3 つのゲートのどれにも一致しない → 直接実行。日常の操作の大部分はこの経路を通る。
@@ -59,9 +59,9 @@ def check_deny_list(command: str) -> str | None:
 ```python
 PERMISSION_RULES = [
     {
-        "tools": ["write_file", "edit_file"],
+        "tools": ["read_file", "write_file", "edit_file"],
         "check": lambda args: not (WORKDIR / args.get("path", "")).resolve().is_relative_to(WORKDIR),
-        "message": "Writing outside workspace",
+        "message": "Access outside workspace",
     },
     {
         "tools": ["bash"],

--- a/s03_permission/README.md
+++ b/s03_permission/README.md
@@ -28,7 +28,7 @@ s02 的循环完全保留。唯一的变动在工具执行前插入 `check_permi
 | 闸门 | 作用 | 命中后 |
 |------|------|--------|
 | 1. 拒绝列表 | 永远禁止的操作（`rm -rf /`、`sudo`） | 直接拒绝，不执行 |
-| 2. 规则匹配 | 取决于上下文的操作（写工作区外、`rm` 文件） | 交给闸门 3 |
+| 2. 规则匹配 | 取决于上下文的操作（读/写工作区外、`rm` 文件） | 交给闸门 3 |
 | 3. 用户审批 | 闸门 2 命中后，暂停等用户确认 | 用户决定允许或拒绝 |
 
 三道都没命中 → 直接执行。大部分日常操作走这条路。
@@ -59,9 +59,9 @@ def check_deny_list(command: str) -> str | None:
 ```python
 PERMISSION_RULES = [
     {
-        "tools": ["write_file", "edit_file"],
+        "tools": ["read_file", "write_file", "edit_file"],
         "check": lambda args: not (WORKDIR / args.get("path", "")).resolve().is_relative_to(WORKDIR),
-        "message": "Writing outside workspace",
+        "message": "Access outside workspace",
     },
     {
         "tools": ["bash"],

--- a/s03_permission/code.py
+++ b/s03_permission/code.py
@@ -58,10 +58,12 @@ SYSTEM = f"You are a coding agent at {WORKDIR}. All destructive operations requi
 # ═══════════════════════════════════════════════════════════
 
 def safe_path(p: str) -> Path:
-    path = (WORKDIR / p).resolve()
-    if not path.is_relative_to(WORKDIR):
-        raise ValueError(f"Path escapes workspace: {p}")
-    return path
+    """Convert a string path to a resolved Path relative to WORKDIR.
+    
+    NOTE: Path escape checking is now handled by Gate 2 (PERMISSION_RULES),
+    which asks the user for approval. safe_path only does str→Path conversion.
+    """
+    return (WORKDIR / p).resolve()
 
 
 def run_bash(command: str) -> str:
@@ -76,7 +78,8 @@ def run_bash(command: str) -> str:
 
 def run_read(path: str, limit: int | None = None) -> str:
     try:
-        lines = safe_path(path).read_text().splitlines()
+        file_path = (WORKDIR / path).resolve()
+        lines = file_path.read_text().splitlines()
         if limit and limit < len(lines):
             lines = lines[:limit] + [f"... ({len(lines) - limit} more lines)"]
         return "\n".join(lines)
@@ -86,7 +89,7 @@ def run_read(path: str, limit: int | None = None) -> str:
 
 def run_write(path: str, content: str) -> str:
     try:
-        file_path = safe_path(path)
+        file_path = (WORKDIR / path).resolve()
         file_path.parent.mkdir(parents=True, exist_ok=True)
         file_path.write_text(content)
         return f"Wrote {len(content)} bytes to {path}"
@@ -96,7 +99,7 @@ def run_write(path: str, content: str) -> str:
 
 def run_edit(path: str, old_text: str, new_text: str) -> str:
     try:
-        file_path = safe_path(path)
+        file_path = (WORKDIR / path).resolve()
         text = file_path.read_text()
         if old_text not in text:
             return f"Error: text not found in {path}"
@@ -157,9 +160,9 @@ def check_deny_list(command: str) -> str | None:
 
 # Gate 2: Rule matching — context-dependent checks
 PERMISSION_RULES = [
-    {"tools": ["write_file", "edit_file"],
+    {"tools": ["read_file", "write_file", "edit_file"],
      "check": lambda args: not (WORKDIR / args.get("path", "")).resolve().is_relative_to(WORKDIR),
-     "message": "Writing outside workspace"},
+     "message": "Access outside workspace"},
     {"tools": ["bash"],
      "check": lambda args: any(kw in args.get("command", "") for kw in ["rm ", "> /etc/", "chmod 777"]),
      "message": "Potentially destructive command"},

--- a/s03_permission/code.py
+++ b/s03_permission/code.py
@@ -54,17 +54,8 @@ SYSTEM = f"You are a coding agent at {WORKDIR}. All destructive operations requi
 
 
 # ═══════════════════════════════════════════════════════════
-#  FROM s02 (unchanged): Tool Implementations
+#  FROM s02 : Tool Implementations
 # ═══════════════════════════════════════════════════════════
-
-def safe_path(p: str) -> Path:
-    """Convert a string path to a resolved Path relative to WORKDIR.
-    
-    NOTE: Path escape checking is now handled by Gate 2 (PERMISSION_RULES),
-    which asks the user for approval. safe_path only does str→Path conversion.
-    """
-    return (WORKDIR / p).resolve()
-
 
 def run_bash(command: str) -> str:
     try:

--- a/s04_hooks/README.en.md
+++ b/s04_hooks/README.en.md
@@ -108,7 +108,7 @@ def permission_hook(block):
         for pattern in DENY_LIST:
             if pattern in block.input.get("command", ""):
                 return "Permission denied by deny list"
-    if block.name in ("write_file", "edit_file"):
+    if block.name in ("read_file", "write_file", "edit_file"):
         path = block.input.get("path", "")
         if not (WORKDIR / path).resolve().is_relative_to(WORKDIR):
             choice = input("   Allow? [y/N] ").strip().lower()

--- a/s04_hooks/README.ja.md
+++ b/s04_hooks/README.ja.md
@@ -108,7 +108,7 @@ def permission_hook(block):
         for pattern in DENY_LIST:
             if pattern in block.input.get("command", ""):
                 return "Permission denied by deny list"
-    if block.name in ("write_file", "edit_file"):
+    if block.name in ("read_file", "write_file", "edit_file"):
         path = block.input.get("path", "")
         if not (WORKDIR / path).resolve().is_relative_to(WORKDIR):
             choice = input("   Allow? [y/N] ").strip().lower()

--- a/s04_hooks/README.md
+++ b/s04_hooks/README.md
@@ -108,7 +108,7 @@ def permission_hook(block):
         for pattern in DENY_LIST:
             if pattern in block.input.get("command", ""):
                 return "Permission denied by deny list"
-    if block.name in ("write_file", "edit_file"):
+    if block.name in ("read_file", "write_file", "edit_file"):
         path = block.input.get("path", "")
         if not (WORKDIR / path).resolve().is_relative_to(WORKDIR):
             choice = input("   Allow? [y/N] ").strip().lower()

--- a/s04_hooks/code.py
+++ b/s04_hooks/code.py
@@ -75,16 +75,8 @@ SYSTEM = f"You are a coding agent at {WORKDIR}. Use tools to solve tasks. Act, d
 
 
 # ═══════════════════════════════════════════════════════════
-#  FROM s02-s03 (unchanged): Tool Implementations
+#  FROM s02-s03 : Tool Implementations
 # ═══════════════════════════════════════════════════════════
-
-def safe_path(p: str) -> Path:
-    """Convert a string path to a resolved Path relative to WORKDIR.
-    
-    NOTE: Path escape checking is now handled by permission_hook,
-    which asks the user for approval. safe_path only does str→Path conversion.
-    """
-    return (WORKDIR / p).resolve()
 
 def run_bash(command: str) -> str:
     try:

--- a/s04_hooks/code.py
+++ b/s04_hooks/code.py
@@ -79,10 +79,12 @@ SYSTEM = f"You are a coding agent at {WORKDIR}. Use tools to solve tasks. Act, d
 # ═══════════════════════════════════════════════════════════
 
 def safe_path(p: str) -> Path:
-    path = (WORKDIR / p).resolve()
-    if not path.is_relative_to(WORKDIR):
-        raise ValueError(f"Path escapes workspace: {p}")
-    return path
+    """Convert a string path to a resolved Path relative to WORKDIR.
+    
+    NOTE: Path escape checking is now handled by permission_hook,
+    which asks the user for approval. safe_path only does str→Path conversion.
+    """
+    return (WORKDIR / p).resolve()
 
 def run_bash(command: str) -> str:
     try:
@@ -95,7 +97,8 @@ def run_bash(command: str) -> str:
 
 def run_read(path: str, limit: int | None = None) -> str:
     try:
-        lines = safe_path(path).read_text().splitlines()
+        file_path = (WORKDIR / path).resolve()
+        lines = file_path.read_text().splitlines()
         if limit and limit < len(lines):
             lines = lines[:limit] + [f"... ({len(lines) - limit} more lines)"]
         return "\n".join(lines)
@@ -104,7 +107,7 @@ def run_read(path: str, limit: int | None = None) -> str:
 
 def run_write(path: str, content: str) -> str:
     try:
-        file_path = safe_path(path)
+        file_path = (WORKDIR / path).resolve()
         file_path.parent.mkdir(parents=True, exist_ok=True)
         file_path.write_text(content)
         return f"Wrote {len(content)} bytes to {path}"
@@ -113,7 +116,7 @@ def run_write(path: str, content: str) -> str:
 
 def run_edit(path: str, old_text: str, new_text: str) -> str:
     try:
-        file_path = safe_path(path)
+        file_path = (WORKDIR / path).resolve()
         text = file_path.read_text()
         if old_text not in text:
             return f"Error: text not found in {path}"
@@ -187,10 +190,10 @@ def permission_hook(block):
                 choice = input("   Allow? [y/N] ").strip().lower()
                 if choice not in ("y", "yes"):
                     return "Permission denied by user"
-    if block.name in ("write_file", "edit_file"):
+    if block.name in ("read_file", "write_file", "edit_file"):
         path = block.input.get("path", "")
         if not (WORKDIR / path).resolve().is_relative_to(WORKDIR):
-            print(f"\n\033[33m⚠  Writing outside workspace\033[0m")
+            print(f"\n\033[33m⚠  Access outside workspace\033[0m")
             print(f"   Tool: {block.name}({block.input})")
             choice = input("   Allow? [y/N] ").strip().lower()
             if choice not in ("y", "yes"):

--- a/s20_comprehensive/code.py
+++ b/s20_comprehensive/code.py
@@ -377,13 +377,13 @@ def assemble_system_prompt(context: dict) -> str:
 # ── Basic Tools ──
 
 def safe_path(p: str, cwd: Path = None) -> Path:
-    # File tools stay inside the workspace or teammate worktree. Bash remains
-    # powerful on purpose and is controlled by the permission hook instead.
+    """Convert a string path to a resolved Path relative to base.
+    
+    NOTE: Path escape checking is now handled by permission_hook,
+    which asks the user for approval. safe_path only does str→Path conversion.
+    """
     base = cwd or WORKDIR
-    path = (base / p).resolve()
-    if not path.is_relative_to(base):
-        raise ValueError(f"Path escapes workspace: {p}")
-    return path
+    return (base / p).resolve()
 
 
 def run_bash(command: str, cwd: Path = None,
@@ -401,7 +401,9 @@ def run_bash(command: str, cwd: Path = None,
 def run_read(path: str, limit: int | None = None,
              offset: int = 0, cwd: Path = None) -> str:
     try:
-        lines = safe_path(path, cwd).read_text().splitlines()
+        base = cwd or WORKDIR
+        file_path = (base / path).resolve()
+        lines = file_path.read_text().splitlines()
         offset = max(int(offset or 0), 0)
         limit = int(limit) if limit is not None else None
         lines = lines[offset:]
@@ -414,7 +416,8 @@ def run_read(path: str, limit: int | None = None,
 
 def run_write(path: str, content: str, cwd: Path = None) -> str:
     try:
-        fp = safe_path(path, cwd)
+        base = cwd or WORKDIR
+        fp = (base / path).resolve()
         fp.parent.mkdir(parents=True, exist_ok=True)
         fp.write_text(content)
         return f"Wrote {len(content)} bytes to {path}"
@@ -425,7 +428,8 @@ def run_write(path: str, content: str, cwd: Path = None) -> str:
 def run_edit(path: str, old_text: str, new_text: str,
              cwd: Path = None) -> str:
     try:
-        fp = safe_path(path, cwd)
+        base = cwd or WORKDIR
+        fp = (base / path).resolve()
         text = fp.read_text()
         if old_text not in text:
             return f"Error: text not found in {path}"
@@ -909,12 +913,14 @@ def permission_hook(block):
             choice = input("  Allow? [y/N] ").strip().lower()
             if choice not in ("y", "yes"):
                 return "Permission denied by user"
-    if block.name in ("write_file", "edit_file"):
+    if block.name in ("read_file", "write_file", "edit_file"):
         path = block.input.get("path", "")
-        try:
-            safe_path(path)
-        except Exception:
-            return f"Permission denied: path escapes workspace: {path}"
+        if not (WORKDIR / path).resolve().is_relative_to(WORKDIR):
+            print(f"\n\033[33m[permission] Access outside workspace\033[0m")
+            print(f"  {block.name}: {path}")
+            choice = input("  Allow? [y/N] ").strip().lower()
+            if choice not in ("y", "yes"):
+                return "Permission denied by user"
     if block.name.startswith("mcp__") and "deploy" in block.name:
         print(f"\n\033[33m[permission] MCP destructive-looking tool: {block.name}\033[0m")
         choice = input("  Allow? [y/N] ").strip().lower()

--- a/s20_comprehensive/code.py
+++ b/s20_comprehensive/code.py
@@ -376,16 +376,6 @@ def assemble_system_prompt(context: dict) -> str:
 
 # ── Basic Tools ──
 
-def safe_path(p: str, cwd: Path = None) -> Path:
-    """Convert a string path to a resolved Path relative to base.
-    
-    NOTE: Path escape checking is now handled by permission_hook,
-    which asks the user for approval. safe_path only does str→Path conversion.
-    """
-    base = cwd or WORKDIR
-    return (base / p).resolve()
-
-
 def run_bash(command: str, cwd: Path = None,
              run_in_background: bool = False) -> str:
     # run_in_background is consumed by the dispatcher; direct execution ignores it.


### PR DESCRIPTION
Supersedes #483. Credits to @ClearVIper3 for the initial s03 fix, extended here to s04 and s20.

## Problem

In s03, Gate 2 (PERMISSION_RULES) and safe_path() used the same path check but with contradictory semantics:

- Gate 2: soft rule — asks user "Allow? [y/N]" — answering y should permit
- safe_path(): hard error — unconditionally raises ValueError("Path escapes workspace")

Result: user approval at Gate 2 was never effective — safe_path always blocked execution first.

The same bug exists in s04_hooks and s20_comprehensive.

## Fix

- Delete safe_path — path safety is now solely the permission layer's responsibility
- Inline path resolution in run_read, run_write, run_edit via (WORKDIR / path).resolve()
- Add read_file to Gate 2 coverage (previously only write_file/edit_file)
- Rename message to "Access outside workspace" (was "Writing", now covers reads)
- Sync READMEs (all 3 languages per module)

## Files changed

s03_permission/code.py: Delete safe_path, inline paths, expand Gate 2 to read_file
s03_permission/README.*.md (3): Update Gate 2 table + code snippet
s04_hooks/code.py: Same fix: delete safe_path, inline paths, expand permission_hook
s04_hooks/README.*.md (3): Update permission_hook snippet
s20_comprehensive/code.py: Same fix + replace safe_path-based try/except with user prompt
s20_comprehensive/README.*.md: (no snippet to update)

## Intentionally NOT changed

s05~s08: their permission_hook only checks bash deny list — path checking is absent from the permission layer. safe_path is their only path defense and must stay.

Closes #482
