### PR TITLE
docs(s17): fix incorrect s16 comparison in changes-from-s16 table

### DIFF
--- a/s17_autonomous_agents/README.en.md
+++ b/s17_autonomous_agents/README.en.md
@@ -195,15 +195,15 @@ Two teammates claim and work in parallel. Lead only creates tasks and spawns tea
 | Component | Before (s16) | After (s17) |
 |-----------|-------------|-------------|
 | Task assignment | Lead manually assigns | Teammates auto-claim (can_start checks deps) |
-| Teammate state | WORK or exit | WORK → IDLE (60s poll) → SHUTDOWN |
+| Teammate state | WORK → IDLE (1s inbox poll) → WORK / SHUTDOWN | WORK → IDLE (5s inbox + task board poll, 60s timeout) → WORK / SHUTDOWN |
 | claim_task | No owner check | Rejects tasks that already have an owner |
-| IDLE phase shutdown | Doesn't handle shutdown_request | Dispatches shutdown immediately and exits |
-| Lead inbox | Prints only, not in context | consume_lead_inbox injects into history |
-| New functions | — | idle_poll, scan_unclaimed_tasks, consume_lead_inbox |
+| IDLE phase shutdown | Exits after receiving shutdown_request | Dispatches shutdown immediately and exits |
+| Lead inbox | consume_lead_inbox routes protocol responses and injects into context | Reuses consume_lead_inbox mechanism |
+| New functions | consume_lead_inbox already exists | idle_poll, scan_unclaimed_tasks (reuses consume_lead_inbox) |
 | Identity persistence | System prompt only | Auto re-inject after compression |
-| Lead tools | 14 (s16) | 14 (unchanged) |
+| Lead tools | 14 | 14 (unchanged) |
 | Teammate tools | 5 | 8 (+ list_tasks, claim_task, complete_task) |
-| Teammate exit | Exit after task done | Exit only after 60s idle timeout |
+| Teammate exit | WORK ends → enters IDLE, waits for shutdown_request (no timeout) | Exits after 60s idle timeout or receiving shutdown_request |
 
 ---
 

--- a/s17_autonomous_agents/README.ja.md
+++ b/s17_autonomous_agents/README.ja.md
@@ -195,15 +195,15 @@ if len(messages) <= 3:
 | コンポーネント | 変更前 (s16) | 変更後 (s17) |
 |--------------|------------|------------|
 | タスク割り当て | Lead が手動 assign | チームメイトが自動認領（can_start で依存確認） |
-| チームメイト状態 | WORK または終了 | WORK → IDLE（60s ポーリング） → SHUTDOWN |
+| チームメイト状態 | WORK → IDLE（1s 間隔で inbox をポーリング）→ WORK / SHUTDOWN | WORK → IDLE（5s 間隔で inbox + タスクボードをポーリング、60s タイムアウト）→ WORK / SHUTDOWN |
 | claim_task | owner チェックなし | 既に owner があるタスクを拒否 |
-| IDLE フェーズシャットダウン | shutdown_request を処理しない | 即座にシャットダウンをディスパッチして終了 |
-| Lead inbox | 印刷のみ、コンテキストに入らない | consume_lead_inbox で history に注入 |
-| 新規関数 | — | idle_poll, scan_unclaimed_tasks, consume_lead_inbox |
+| IDLE フェーズシャットダウン | shutdown_request を受信後に終了 | 即座にシャットダウンをディスパッチして終了 |
+| Lead inbox | consume_lead_inbox がプロトコル応答をルーティングしコンテキストに注入 | consume_lead_inbox 機構を踏襲 |
+| 新規関数 | consume_lead_inbox は既存 | idle_poll, scan_unclaimed_tasks（consume_lead_inbox を踏襲） |
 | 身份保持 | system prompt のみ | 圧縮後に自動再注入 |
-| Lead ツール | 14 (s16) | 14（変更なし） |
+| Lead ツール | 14 | 14（変更なし） |
 | チームメイトツール | 5 | 8（+ list_tasks, claim_task, complete_task） |
-| チームメイト終了条件 | タスク完了後即終了 | 60s アイドルタイムアウト後のみ終了 |
+| チームメイト終了条件 | WORK 完了後 IDLE に入り、shutdown_request を待って終了（タイムアウトなし） | 60s アイドルタイムアウトまたは shutdown_request 受信で終了 |
 
 ---
 

--- a/s17_autonomous_agents/README.md
+++ b/s17_autonomous_agents/README.md
@@ -195,15 +195,15 @@ if len(messages) <= 3:
 | 组件 | 之前 (s16) | 之后 (s17) |
 |------|-----------|-----------|
 | 任务分配 | Lead 手动 assign | 队友自动认领（can_start 检查依赖） |
-| 队友状态 | WORK 或退出 | WORK → IDLE（轮询 60s） → SHUTDOWN |
+| 队友状态 | WORK → IDLE（每 1s 轮询 inbox）→ WORK / SHUTDOWN | WORK → IDLE（每 5s 轮询 inbox + 任务板，60s 超时）→ WORK / SHUTDOWN |
 | claim_task | 无 owner 检查 | 拒绝已有 owner 的任务 |
-| IDLE 阶段关机 | 不处理 shutdown_request | 直接 dispatch shutdown 并退出 |
-| Lead inbox | 只打印，不进上下文 | consume_lead_inbox 统一注入 history |
-| 新函数 | — | idle_poll, scan_unclaimed_tasks, consume_lead_inbox |
+| IDLE 阶段关机 | 收到 shutdown_request 后退出 | 直接 dispatch shutdown 并退出 |
+| Lead inbox | consume_lead_inbox 路由协议响应并注入上下文 | 沿用 consume_lead_inbox 机制 |
+| 新函数 | 已有 consume_lead_inbox | idle_poll, scan_unclaimed_tasks（沿用 consume_lead_inbox） |
 | 身份保持 | 仅 system prompt | 压缩后自动重注入 |
-| Lead 工具 | 14 (s16) | 14（不变） |
+| Lead 工具 | 14 | 14（不变） |
 | 队友工具 | 5 | 8（+ list_tasks, claim_task, complete_task） |
-| 队友退出条件 | 完成任务即退出 | 60s 无新任务才退出 |
+| 队友退出条件 | WORK 完进入 IDLE，等待 shutdown_request 后退出（无超时） | 60s 无新任务或收到 shutdown_request 后退出 |
 
 ---
 


### PR DESCRIPTION
The "Changes from s16" table in s17's README had several inaccurate entries for the s16 column. s16 already had a WORK→IDLE→SHUTDOWN state machine, handled shutdown_request during IDLE, and used consume_lead_inbox for protocol routing and history injection — but the table described s16 as having none of these.

This updates the table so the s16 column reflects what s16 actually does, verified against s16_team_protocols/code.py. All three README languages are synchronized.

Closes #480.
