### PR TITLE
docs(s08): clarify reactive_compact aggressive wording refers to trigger, not compression

### DIFF
--- a/s08_context_compact/README.en.md
+++ b/s08_context_compact/README.en.md
@@ -136,7 +136,7 @@ def compact_history(messages):
 
 Sometimes the API still returns `prompt_too_long` (413) — when context grows faster than compression triggers.
 
-This triggers **reactive_compact**: more aggressive than compact_history, it retreats from the tail, but still avoids leaving an orphaned `tool_result`.
+This triggers **reactive_compact**: more aggressive than compact_history in trigger (emergency response to a 413 error), but more conservative in what it removes, keeping ~5 recent messages and only summarizing earlier history. Still avoids an orphaned `tool_result`.
 
 ```python
 def reactive_compact(messages):

--- a/s08_context_compact/README.ja.md
+++ b/s08_context_compact/README.ja.md
@@ -136,7 +136,7 @@ def compact_history(messages):
 
 API がまだ `prompt_too_long`（413）を返すことがある。コンテキストの増加速度が圧縮のトリガー速度を上回る場合。
 
-この時 **reactive_compact** がトリガーされる：compact_history よりもさらに積極的だが、末尾を残す際も孤立した `tool_result` を残さないようにする。
+この時 **reactive_compact** がトリガーされる。トリガー方式は compact_history より積極的（413 エラー後の緊急対応）だが、圧縮方針はより温和で、末尾約 5 件のメッセージを保持し、早期の履歴だけを要約する。孤立した `tool_result` を残さないよう配慮する。
 
 ```python
 def reactive_compact(messages):

--- a/s08_context_compact/README.md
+++ b/s08_context_compact/README.md
@@ -136,7 +136,7 @@ def compact_history(messages):
 
 有时候 API 还是返回 `prompt_too_long`（413），上下文增长速度快于压缩触发速度时。
 
-这时触发 **reactive_compact**：比 compact_history 更激进，从尾部回退，但仍要避免留下孤立 `tool_result`。
+这时触发 **reactive_compact**：触发方式比 compact_history 更激进（API 报错后的应急手段），但压缩策略更温和，保留最近约 5 条原始消息，只总结较早历史。同样避免留下孤立 `tool_result`。
 
 ```python
 def reactive_compact(messages):


### PR DESCRIPTION
The original wording described reactive_compact as "more aggressive than compact_history", but the code shows it is actually more conservative in compression (keeps ~5 recent messages vs replacing everything with a summary). The real difference is the trigger mechanism: reactive_compact is an emergency last-resort response to a 413 error, not a proactive threshold-based trigger.

This clarifies in all three README languages that the aggressiveness refers to the trigger, not the compression strategy.

Closes #467.
