### PR TITLE
fix(s10): assemble system prompt from dynamic context instead of static strings

### DIFF
--- a/s10_system_prompt/README.en.md
+++ b/s10_system_prompt/README.en.md
@@ -68,9 +68,6 @@ Split the monolithic string into a dictionary, each key is a topic:
 ```python
 PROMPT_SECTIONS = {
     "identity": "You are a coding agent. Act, don't explain.",
-    "tools": "Available tools: bash, read_file, write_file.",
-    "workspace": f"Working directory: {WORKDIR}",
-    "memory": "Relevant memories are injected below when available.",
 }
 ```
 
@@ -86,8 +83,12 @@ def assemble_system_prompt(context: dict) -> str:
 
     # Always loaded
     sections.append(PROMPT_SECTIONS["identity"])
-    sections.append(PROMPT_SECTIONS["tools"])
-    sections.append(PROMPT_SECTIONS["workspace"])
+
+    # Dynamic — tools and workspace from context
+    tools = ", ".join(context.get("enabled_tools", []))
+    if tools:
+        sections.append(f"Available tools: {tools}.")
+    sections.append(f"Working directory: {context.get("workspace", WORKDIR)}")
 
     # On-demand — based on real state, not keywords
     memories = context.get("memories", "")

--- a/s10_system_prompt/README.ja.md
+++ b/s10_system_prompt/README.ja.md
@@ -68,9 +68,6 @@ s10 は prompt アセンブリ機構に焦点を当てる。s08-s09 の能力を
 ```python
 PROMPT_SECTIONS = {
     "identity": "You are a coding agent. Act, don't explain.",
-    "tools": "Available tools: bash, read_file, write_file.",
-    "workspace": f"Working directory: {WORKDIR}",
-    "memory": "Relevant memories are injected below when available.",
 }
 ```
 
@@ -86,8 +83,12 @@ def assemble_system_prompt(context: dict) -> str:
 
     # 常にロード
     sections.append(PROMPT_SECTIONS["identity"])
-    sections.append(PROMPT_SECTIONS["tools"])
-    sections.append(PROMPT_SECTIONS["workspace"])
+
+    # context から動的に tools と workspace を取得
+    tools = ", ".join(context.get("enabled_tools", []))
+    if tools:
+        sections.append(f"Available tools: {tools}.")
+    sections.append(f"Working directory: {context.get("workspace", WORKDIR)}")
 
     # オンデマンド — 実際の状態に基づく、キーワードではない
     memories = context.get("memories", "")

--- a/s10_system_prompt/README.md
+++ b/s10_system_prompt/README.md
@@ -68,9 +68,6 @@ s10 聚焦 prompt 组装机制。以 s08-s09 的能力为背景，但不重复�
 ```python
 PROMPT_SECTIONS = {
     "identity": "You are a coding agent. Act, don't explain.",
-    "tools": "Available tools: bash, read_file, write_file.",
-    "workspace": f"Working directory: {WORKDIR}",
-    "memory": "Relevant memories are injected below when available.",
 }
 ```
 
@@ -86,8 +83,12 @@ def assemble_system_prompt(context: dict) -> str:
 
     # 始终加载
     sections.append(PROMPT_SECTIONS["identity"])
-    sections.append(PROMPT_SECTIONS["tools"])
-    sections.append(PROMPT_SECTIONS["workspace"])
+
+    # 从 context 动态获取 tools 和 workspace
+    tools = ", ".join(context.get("enabled_tools", []))
+    if tools:
+        sections.append(f"Available tools: {tools}.")
+    sections.append(f"Working directory: {context.get("workspace", WORKDIR)}")
 
     # 按需加载 — 基于真实状态，不是关键词
     memories = context.get("memories", "")

--- a/s10_system_prompt/code.py
+++ b/s10_system_prompt/code.py
@@ -41,9 +41,6 @@ MODEL = os.environ["MODEL_ID"]
 
 PROMPT_SECTIONS = {
     "identity": "You are a coding agent. Act, don't explain.",
-    "tools": "Available tools: bash, read_file, write_file.",
-    "workspace": f"Working directory: {WORKDIR}",
-    "memory": "Relevant memories are injected below when available.",
 }
 
 
@@ -51,10 +48,14 @@ def assemble_system_prompt(context: dict) -> str:
     """Select and join prompt sections based on current context."""
     sections = []
 
-    # Always loaded — identity, tools, workspace
+    # Always loaded — identity
     sections.append(PROMPT_SECTIONS["identity"])
-    sections.append(PROMPT_SECTIONS["tools"])
-    sections.append(PROMPT_SECTIONS["workspace"])
+
+    # Dynamic — tools and workspace from context
+    tools = ", ".join(context.get("enabled_tools", []))
+    if tools:
+        sections.append(f"Available tools: {tools}.")
+    sections.append(f"Working directory: {context.get("workspace", WORKDIR)}")
 
     # Conditional — memory loaded when MEMORY.md exists and has content
     memories = context.get("memories", "")


### PR DESCRIPTION
PROMPT_SECTIONS["memory"] was defined but never referenced, and update_context() collected enabled_tools and workspace that assemble_system_prompt() ignored, using hardcoded strings instead. This undermined the chapter's core demonstration of runtime prompt assembly from context.

Now assemble_system_prompt reads tools and workspace from the context dict, and PROMPT_SECTIONS only holds the identity line. All three README code snippets are synchronized.

Closes #471.
