### PR TITLE
docs(s16): fix protocol flowchart — separate shutdown and plan approval flows

### DIFF
--- a/s16_team_protocols/images/team-protocols-overview.en.svg
+++ b/s16_team_protocols/images/team-protocols-overview.en.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 760 500" font-family="system-ui, -apple-system, sans-serif">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 760 664" font-family="system-ui, -apple-system, sans-serif">
   <defs>
     <linearGradient id="header" x1="0" y1="0" x2="1" y2="0">
       <stop offset="0%" stop-color="#1e3a5f"/><stop offset="100%" stop-color="#7c3aed"/>
@@ -9,9 +9,6 @@
     <marker id="arrow-purple" viewBox="0 0 10 10" refX="10" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
       <path d="M 0 0 L 10 5 L 0 10 z" fill="#7c3aed"/>
     </marker>
-    <marker id="arrow-cyan" viewBox="0 0 10 10" refX="10" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
-      <path d="M 0 0 L 10 5 L 0 10 z" fill="#0891b2"/>
-    </marker>
     <marker id="arrow-green" viewBox="0 0 10 10" refX="10" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
       <path d="M 0 0 L 10 5 L 0 10 z" fill="#16a34a"/>
     </marker>
@@ -20,124 +17,125 @@
     </marker>
   </defs>
 
-  <rect width="760" height="500" fill="#fafbfc" rx="8"/>
+  <rect width="760" height="664" fill="#fafbfc" rx="8"/>
 
-  <!-- Title -->
   <rect x="0" y="0" width="760" height="44" fill="url(#header)" rx="8"/>
   <rect x="0" y="36" width="760" height="8" fill="url(#header)"/>
   <text x="380" y="28" fill="#fff" font-size="15" font-weight="700" text-anchor="middle">Team Protocols — Request-Response + request_id Correlation + State Machine</text>
 
-  <!-- Legend -->
   <rect x="40" y="56" width="12" height="10" rx="2" fill="#f0f4ff" stroke="#2563eb" stroke-width="1"/>
   <text x="58" y="66" fill="#2563eb" font-size="10" font-weight="600">s15 Preserved</text>
   <rect x="160" y="56" width="12" height="10" rx="2" fill="#f5f3ff" stroke="#7c3aed" stroke-width="1"/>
   <text x="178" y="66" fill="#7c3aed" font-size="10" font-weight="600">s16 New</text>
 
-  <!-- ===== Row 1: Lead Loop ===== -->
+  <!-- Row 1: Lead Loop -->
   <rect x="20" y="90" width="70" height="40" rx="8" fill="#eef2ff" stroke="#4f46e5" stroke-width="1.5"/>
   <text x="55" y="114" fill="#4f46e5" font-size="8" font-weight="600" text-anchor="middle">turn</text>
-
   <line x1="90" y1="110" x2="104" y2="110" stroke="#555" stroke-width="1.5" marker-end="url(#arrow)"/>
-
   <rect x="107" y="90" width="70" height="40" rx="8" fill="#f0f4ff" stroke="#2563eb" stroke-width="1.5"/>
   <text x="142" y="114" fill="#1e3a5f" font-size="10" font-weight="600" text-anchor="middle">messages</text>
-
   <line x1="177" y1="110" x2="191" y2="110" stroke="#555" stroke-width="1.5" marker-end="url(#arrow)"/>
-
   <rect x="194" y="86" width="80" height="48" rx="8" fill="#f0f4ff" stroke="#2563eb" stroke-width="1.5"/>
   <text x="234" y="114" fill="#1e3a5f" font-size="9" font-weight="600" text-anchor="middle">prompt</text>
-
   <line x1="274" y1="110" x2="288" y2="110" stroke="#555" stroke-width="1.5" marker-end="url(#arrow)"/>
-
   <rect x="291" y="86" width="70" height="48" rx="8" fill="#f0f4ff" stroke="#2563eb" stroke-width="1.5"/>
   <text x="326" y="114" fill="#1e3a5f" font-size="9" font-weight="600" text-anchor="middle">LLM</text>
-
   <line x1="361" y1="110" x2="375" y2="110" stroke="#555" stroke-width="1.5" marker-end="url(#arrow)"/>
-
   <rect x="378" y="80" width="356" height="60" rx="8" fill="#f0f4ff" stroke="#2563eb" stroke-width="1.5"/>
   <text x="556" y="98" fill="#1e3a5f" font-size="10" font-weight="600" text-anchor="middle">TOOL DISPATCH (core tool set)</text>
   <text x="394" y="114" fill="#2563eb" font-size="8">bash · read · write · task(4) · spawn · send · inbox</text>
   <text x="394" y="128" fill="#7c3aed" font-size="8" font-weight="700">★ request_shutdown · request_plan · review_plan</text>
-
-  <!-- Loop back -->
   <path d="M 734 110 L 748 110 L 748 150 L 55 150 L 55 130" fill="none" stroke="#94a3b8" stroke-width="1" marker-end="url(#arrow)" stroke-dasharray="5,4"/>
 
-  <!-- ===== Row 2: Protocol Flow (purple) — request_id lifecycle ===== -->
-  <rect x="30" y="176" width="700" height="100" rx="8" fill="#f5f3ff" stroke="#7c3aed" stroke-width="2"/>
-  <text x="380" y="196" fill="#4c1d95" font-size="11" font-weight="700" text-anchor="middle">Request-Response Protocol Flow (request_id throughout)</text>
+  <!-- Row 2: shutdown protocol -->
+  <rect x="30" y="176" width="700" height="90" rx="8" fill="#fef3c7" stroke="#d97706" stroke-width="1.5"/>
+  <text x="380" y="196" fill="#92400e" font-size="11" font-weight="700" text-anchor="middle">Protocol A: Shutdown (Lead initiates → Teammate responds)</text>
 
-  <!-- Step 1: Send request -->
-  <rect x="50" y="208" width="130" height="52" rx="6" fill="#fff" stroke="#7c3aed" stroke-width="1"/>
-  <text x="115" y="226" fill="#7c3aed" font-size="9" font-weight="600" text-anchor="middle">① Lead sends request</text>
-  <text x="115" y="240" fill="#6b7280" font-size="7" text-anchor="middle">BUS.send("shutdown_request"</text>
-  <text x="115" y="252" fill="#6b7280" font-size="7" text-anchor="middle">metadata={request_id})</text>
+  <rect x="50" y="208" width="180" height="46" rx="6" fill="#fff" stroke="#d97706" stroke-width="1"/>
+  <text x="140" y="226" fill="#92400e" font-size="9" font-weight="600" text-anchor="middle">① Lead: request_shutdown</text>
+  <text x="140" y="242" fill="#6b7280" font-size="7" text-anchor="middle">new_request_id() → ProtocolState</text>
 
-  <line x1="180" y1="234" x2="206" y2="234" stroke="#7c3aed" stroke-width="1.5" marker-end="url(#arrow-purple)"/>
+  <line x1="230" y1="231" x2="254" y2="231" stroke="#d97706" stroke-width="1.5" marker-end="url(#arrow)"/>
 
-  <!-- Step 2: Teammate receives & dispatches -->
-  <rect x="209" y="208" width="130" height="52" rx="6" fill="#fff" stroke="#7c3aed" stroke-width="1"/>
-  <text x="274" y="226" fill="#7c3aed" font-size="9" font-weight="600" text-anchor="middle">② Teammate receives</text>
-  <text x="274" y="240" fill="#6b7280" font-size="7" text-anchor="middle">dispatch_by_type(inbox)</text>
-  <text x="274" y="252" fill="#6b7280" font-size="7" text-anchor="middle">→ handler(type, metadata)</text>
+  <rect x="257" y="208" width="180" height="46" rx="6" fill="#fff" stroke="#d97706" stroke-width="1"/>
+  <text x="347" y="226" fill="#92400e" font-size="9" font-weight="600" text-anchor="middle">② Teammate: handle_shutdown</text>
+  <text x="347" y="242" fill="#6b7280" font-size="7" text-anchor="middle">ack → shutdown_response</text>
 
-  <line x1="339" y1="234" x2="365" y2="234" stroke="#7c3aed" stroke-width="1.5" marker-end="url(#arrow-purple)"/>
+  <line x1="437" y1="231" x2="461" y2="231" stroke="#d97706" stroke-width="1.5" marker-end="url(#arrow)"/>
 
-  <!-- Step 3: Teammate processes & responds -->
-  <rect x="368" y="208" width="130" height="52" rx="6" fill="#fff" stroke="#7c3aed" stroke-width="1"/>
-  <text x="433" y="226" fill="#7c3aed" font-size="9" font-weight="600" text-anchor="middle">③ Teammate responds</text>
-  <text x="433" y="240" fill="#6b7280" font-size="7" text-anchor="middle">BUS.send("shutdown_response"</text>
-  <text x="433" y="252" fill="#6b7280" font-size="7" text-anchor="middle">same request_id + approve)</text>
+  <rect x="464" y="208" width="180" height="46" rx="6" fill="#fff" stroke="#d97706" stroke-width="1"/>
+  <text x="554" y="226" fill="#92400e" font-size="9" font-weight="600" text-anchor="middle">③ Lead: consume_lead_inbox</text>
+  <text x="554" y="242" fill="#6b7280" font-size="7" text-anchor="middle">match_response(request_id) → ✓</text>
 
-  <line x1="498" y1="234" x2="524" y2="234" stroke="#7c3aed" stroke-width="1.5" marker-end="url(#arrow-purple)"/>
+  <!-- Row 3: plan approval protocol -->
+  <rect x="30" y="280" width="700" height="110" rx="8" fill="#dbeafe" stroke="#2563eb" stroke-width="1.5"/>
+  <text x="380" y="300" fill="#1e40af" font-size="11" font-weight="700" text-anchor="middle">Protocol B: Plan Approval (Teammate initiates → Lead reviews)</text>
 
-  <!-- Step 4: Lead receives response -->
-  <rect x="527" y="208" width="130" height="52" rx="6" fill="#fff" stroke="#7c3aed" stroke-width="1"/>
-  <text x="592" y="226" fill="#7c3aed" font-size="9" font-weight="600" text-anchor="middle">④ Lead receives</text>
-  <text x="592" y="240" fill="#6b7280" font-size="7" text-anchor="middle">match_response(request_id)</text>
-  <text x="592" y="252" fill="#6b7280" font-size="7" text-anchor="middle">→ resolve/reject callback</text>
+  <rect x="50" y="312" width="150" height="46" rx="6" fill="#f1f5f9" stroke="#94a3b8" stroke-width="1"/>
+  <text x="125" y="330" fill="#475569" font-size="8" font-weight="600" text-anchor="middle">0. Lead: request_plan</text>
+  <text x="125" y="346" fill="#6b7280" font-size="7" text-anchor="middle">Plain message (msg_type="message")</text>
 
-  <!-- ===== Row 3: State Machine + Storage ===== -->
-  <!-- State Machine -->
-  <rect x="30" y="296" width="340" height="85" rx="8" fill="#f5f3ff" stroke="#7c3aed" stroke-width="1.5"/>
-  <text x="200" y="316" fill="#4c1d95" font-size="10" font-weight="700" text-anchor="middle">State Machine (same for both protocols)</text>
+  <line x1="200" y1="335" x2="222" y2="335" stroke="#94a3b8" stroke-width="1" marker-end="url(#arrow)" stroke-dasharray="4,3"/>
 
-  <rect x="55" y="330" width="58" height="20" rx="4" fill="#f1f5f9" stroke="#94a3b8" stroke-width="1"/>
-  <text x="84" y="344" fill="#475569" font-size="9" text-anchor="middle">pending</text>
+  <rect x="225" y="312" width="160" height="46" rx="6" fill="#fff" stroke="#2563eb" stroke-width="1"/>
+  <text x="305" y="330" fill="#1e40af" font-size="8" font-weight="600" text-anchor="middle">① Teammate: submit_plan</text>
+  <text x="305" y="346" fill="#6b7280" font-size="7" text-anchor="middle">plan_approval_request + request_id</text>
 
-  <line x1="113" y1="340" x2="192" y2="340" stroke="#16a34a" stroke-width="1.5" marker-end="url(#arrow-green)"/>
-  <text x="152" y="335" fill="#16a34a" font-size="8" font-weight="600" text-anchor="middle">approve</text>
+  <line x1="385" y1="335" x2="407" y2="335" stroke="#2563eb" stroke-width="1.5" marker-end="url(#arrow)"/>
 
-  <rect x="192" y="330" width="62" height="20" rx="4" fill="#dcfce7" stroke="#16a34a" stroke-width="1"/>
-  <text x="223" y="344" fill="#166534" font-size="9" text-anchor="middle">approved</text>
+  <rect x="410" y="312" width="160" height="46" rx="6" fill="#fff" stroke="#2563eb" stroke-width="1"/>
+  <text x="490" y="330" fill="#1e40af" font-size="8" font-weight="600" text-anchor="middle">② Lead: review_plan</text>
+  <text x="490" y="346" fill="#6b7280" font-size="7" text-anchor="middle">plan_approval_response</text>
 
-  <path d="M 84 350 L 84 368 L 128 368" fill="none" stroke="#dc2626" stroke-width="1.5" marker-end="url(#arrow-red)"/>
-  <text x="76" y="362" fill="#dc2626" font-size="8" font-weight="600" text-anchor="end">reject</text>
+  <line x1="570" y1="335" x2="592" y2="335" stroke="#2563eb" stroke-width="1.5" marker-end="url(#arrow)"/>
 
-  <rect x="128" y="358" width="60" height="20" rx="4" fill="#fef2f2" stroke="#dc2626" stroke-width="1"/>
-  <text x="158" y="372" fill="#991b1b" font-size="9" text-anchor="middle">rejected</text>
+  <rect x="595" y="312" width="120" height="46" rx="6" fill="#fff" stroke="#2563eb" stroke-width="1"/>
+  <text x="655" y="330" fill="#1e40af" font-size="8" font-weight="600" text-anchor="middle">③ Teammate: receives</text>
+  <text x="655" y="346" fill="#6b7280" font-size="7" text-anchor="middle">[Plan approved/rejected]</text>
 
-  <!-- pending_requests storage -->
-  <rect x="400" y="296" width="330" height="85" rx="8" fill="#f5f3ff" stroke="#7c3aed" stroke-width="1.5"/>
-  <text x="565" y="316" fill="#4c1d95" font-size="10" font-weight="700" text-anchor="middle">pending_requests Storage</text>
-  <text x="420" y="336" fill="#7c3aed" font-size="9">pending_requests: dict[str, ProtocolState]</text>
-  <text x="420" y="352" fill="#6b7280" font-size="8">request_id → {type, sender, status, created_at}</text>
-  <text x="420" y="368" fill="#6b7280" font-size="8">match_response: find request by request_id</text>
+  <text x="380" y="380" fill="#6b7280" font-size="8" text-anchor="middle">request_plan is a plain message, not a protocol; submit_plan is the protocol entry point (creates ProtocolState on teammate side)</text>
 
-  <!-- ===== Row 4: Two protocols use same machine ===== -->
-  <rect x="30" y="396" width="700" height="48" rx="6" fill="#f8fafc" stroke="#e2e8f0" stroke-width="1"/>
-  <text x="55" y="416" fill="#1e3a5f" font-size="10" font-weight="600">Two protocols, one mechanism:</text>
-  <rect x="230" y="406" width="130" height="18" rx="4" fill="#fef3c7" stroke="#d97706" stroke-width="1"/>
-  <text x="295" y="419" fill="#92400e" font-size="9" text-anchor="middle">shutdown_request</text>
-  <text x="368" y="419" fill="#475569" font-size="10">and</text>
-  <rect x="390" y="406" width="140" height="18" rx="4" fill="#dbeafe" stroke="#2563eb" stroke-width="1"/>
-  <text x="460" y="419" fill="#1e40af" font-size="9" text-anchor="middle">plan_approval_request</text>
-  <text x="540" y="419" fill="#475569" font-size="10">share the same pending→approved/rejected FSM</text>
-  <text x="55" y="436" fill="#6b7280" font-size="8">New protocol type = new msg_type, no new state machine. request_id links request and response.</text>
+  <!-- Row 4: State Machine + Storage -->
+  <rect x="30" y="406" width="340" height="85" rx="8" fill="#f5f3ff" stroke="#7c3aed" stroke-width="1.5"/>
+  <text x="200" y="426" fill="#4c1d95" font-size="10" font-weight="700" text-anchor="middle">State Machine (shared by both protocols)</text>
 
-  <!-- ===== Bottom notes ===== -->
-  <rect x="30" y="460" width="700" height="28" rx="6" fill="#f8fafc" stroke="#e2e8f0" stroke-width="1"/>
-  <rect x="50" y="470" width="12" height="10" rx="2" fill="#f0f4ff" stroke="#2563eb" stroke-width="1"/>
-  <text x="70" y="480" fill="#475569" font-size="10">s15: MessageBus + spawn_teammate + inbox</text>
-  <rect x="310" y="470" width="12" height="10" rx="2" fill="#f5f3ff" stroke="#7c3aed" stroke-width="1"/>
-  <text x="330" y="480" fill="#475569" font-size="10">s16: request_id protocol + dispatch + pending_requests + state machine</text>
+  <rect x="55" y="440" width="58" height="20" rx="4" fill="#f1f5f9" stroke="#94a3b8" stroke-width="1"/>
+  <text x="84" y="454" fill="#475569" font-size="9" text-anchor="middle">pending</text>
+  <line x1="113" y1="450" x2="192" y2="450" stroke="#16a34a" stroke-width="1.5" marker-end="url(#arrow-green)"/>
+  <text x="152" y="445" fill="#16a34a" font-size="8" font-weight="600" text-anchor="middle">approve</text>
+  <rect x="192" y="440" width="62" height="20" rx="4" fill="#dcfce7" stroke="#16a34a" stroke-width="1"/>
+  <text x="223" y="454" fill="#166534" font-size="9" text-anchor="middle">approved</text>
+  <path d="M 84 460 L 84 478 L 128 478" fill="none" stroke="#dc2626" stroke-width="1.5" marker-end="url(#arrow-red)"/>
+  <text x="76" y="472" fill="#dc2626" font-size="8" font-weight="600" text-anchor="end">reject</text>
+  <rect x="128" y="468" width="60" height="20" rx="4" fill="#fef2f2" stroke="#dc2626" stroke-width="1"/>
+  <text x="158" y="482" fill="#991b1b" font-size="9" text-anchor="middle">rejected</text>
+
+  <rect x="400" y="406" width="330" height="85" rx="8" fill="#f5f3ff" stroke="#7c3aed" stroke-width="1.5"/>
+  <text x="565" y="426" fill="#4c1d95" font-size="10" font-weight="700" text-anchor="middle">pending_requests Storage</text>
+  <text x="420" y="446" fill="#7c3aed" font-size="9">pending_requests: dict[str, ProtocolState]</text>
+  <text x="420" y="462" fill="#6b7280" font-size="8">request_id → {type, sender, status, created_at}</text>
+  <text x="420" y="478" fill="#6b7280" font-size="8">match_response: find request by request_id</text>
+
+  <!-- Row 5: Two protocols same machine -->
+  <rect x="30" y="506" width="700" height="52" rx="6" fill="#f8fafc" stroke="#e2e8f0" stroke-width="1"/>
+  <text x="55" y="524" fill="#1e3a5f" font-size="10" font-weight="600">Two protocols, one mechanism:</text>
+  <rect x="230" y="512" width="130" height="18" rx="4" fill="#fef3c7" stroke="#d97706" stroke-width="1"/>
+  <text x="295" y="525" fill="#92400e" font-size="9" text-anchor="middle">shutdown_request</text>
+  <text x="368" y="525" fill="#475569" font-size="10">and</text>
+  <rect x="390" y="512" width="140" height="18" rx="4" fill="#dbeafe" stroke="#2563eb" stroke-width="1"/>
+  <text x="460" y="525" fill="#1e40af" font-size="9" text-anchor="middle">plan_approval_request</text>
+  <text x="55" y="548" fill="#6b7280" font-size="8">Share the same pending → approved / rejected state machine. New protocol type = new msg_type, no new state machine needed. request_id links request and response.</text>
+
+  <!-- Row 6: distinguish -->
+  <rect x="30" y="570" width="700" height="38" rx="6" fill="#f0fdf4" stroke="#16a34a" stroke-width="1"/>
+  <text x="55" y="588" fill="#166534" font-size="9" font-weight="600">Note:</text>
+  <text x="100" y="588" fill="#475569" font-size="9">request_plan is a plain message (msg_type="message") sent by lead to prompt a plan submission.</text>
+  <text x="55" y="602" fill="#475569" font-size="9">submit_plan is the protocol entry point (msg_type="plan_approval_request"), initiated by teammate, carrying request_id into pending_requests.</text>
+
+  <!-- Bottom notes -->
+  <rect x="30" y="622" width="700" height="28" rx="6" fill="#f8fafc" stroke="#e2e8f0" stroke-width="1"/>
+  <rect x="50" y="632" width="12" height="10" rx="2" fill="#f0f4ff" stroke="#2563eb" stroke-width="1"/>
+  <text x="70" y="642" fill="#475569" font-size="10">s15: MessageBus + spawn_teammate + inbox</text>
+  <rect x="310" y="632" width="12" height="10" rx="2" fill="#f5f3ff" stroke="#7c3aed" stroke-width="1"/>
+  <text x="330" y="642" fill="#475569" font-size="10">s16: request_id protocol + dispatch + pending_requests + state machine</text>
 </svg>

--- a/s16_team_protocols/images/team-protocols-overview.ja.svg
+++ b/s16_team_protocols/images/team-protocols-overview.ja.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 760 500" font-family="system-ui, -apple-system, sans-serif">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 760 664" font-family="system-ui, -apple-system, sans-serif">
   <defs>
     <linearGradient id="header" x1="0" y1="0" x2="1" y2="0">
       <stop offset="0%" stop-color="#1e3a5f"/><stop offset="100%" stop-color="#7c3aed"/>
@@ -9,9 +9,6 @@
     <marker id="arrow-purple" viewBox="0 0 10 10" refX="10" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
       <path d="M 0 0 L 10 5 L 0 10 z" fill="#7c3aed"/>
     </marker>
-    <marker id="arrow-cyan" viewBox="0 0 10 10" refX="10" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
-      <path d="M 0 0 L 10 5 L 0 10 z" fill="#0891b2"/>
-    </marker>
     <marker id="arrow-green" viewBox="0 0 10 10" refX="10" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
       <path d="M 0 0 L 10 5 L 0 10 z" fill="#16a34a"/>
     </marker>
@@ -20,122 +17,125 @@
     </marker>
   </defs>
 
-  <rect width="760" height="500" fill="#fafbfc" rx="8"/>
+  <rect width="760" height="664" fill="#fafbfc" rx="8"/>
 
-  <!-- Title -->
   <rect x="0" y="0" width="760" height="44" fill="url(#header)" rx="8"/>
   <rect x="0" y="36" width="760" height="8" fill="url(#header)"/>
   <text x="380" y="28" fill="#fff" font-size="14" font-weight="700" text-anchor="middle">Team Protocols — リクエスト・レスポンス + request_id 紐付け + 状態機械</text>
 
-  <!-- Legend -->
   <rect x="40" y="56" width="12" height="10" rx="2" fill="#f0f4ff" stroke="#2563eb" stroke-width="1"/>
-  <text x="58" y="66" fill="#2563eb" font-size="10" font-weight="600">s15 保持</text>
-  <rect x="130" y="56" width="12" height="10" rx="2" fill="#f5f3ff" stroke="#7c3aed" stroke-width="1"/>
-  <text x="148" y="66" fill="#7c3aed" font-size="10" font-weight="600">s16 新規</text>
+  <text x="58" y="66" fill="#2563eb" font-size="10" font-weight="600">s15 維持</text>
+  <rect x="140" y="56" width="12" height="10" rx="2" fill="#f5f3ff" stroke="#7c3aed" stroke-width="1"/>
+  <text x="158" y="66" fill="#7c3aed" font-size="10" font-weight="600">s16 新規</text>
 
-  <!-- ===== Row 1: Lead Loop ===== -->
+  <!-- Row 1: Lead Loop -->
   <rect x="20" y="90" width="70" height="40" rx="8" fill="#eef2ff" stroke="#4f46e5" stroke-width="1.5"/>
   <text x="55" y="114" fill="#4f46e5" font-size="8" font-weight="600" text-anchor="middle">turn</text>
-
   <line x1="90" y1="110" x2="104" y2="110" stroke="#555" stroke-width="1.5" marker-end="url(#arrow)"/>
-
   <rect x="107" y="90" width="70" height="40" rx="8" fill="#f0f4ff" stroke="#2563eb" stroke-width="1.5"/>
   <text x="142" y="114" fill="#1e3a5f" font-size="10" font-weight="600" text-anchor="middle">messages</text>
-
   <line x1="177" y1="110" x2="191" y2="110" stroke="#555" stroke-width="1.5" marker-end="url(#arrow)"/>
-
   <rect x="194" y="86" width="80" height="48" rx="8" fill="#f0f4ff" stroke="#2563eb" stroke-width="1.5"/>
   <text x="234" y="114" fill="#1e3a5f" font-size="9" font-weight="600" text-anchor="middle">prompt</text>
-
   <line x1="274" y1="110" x2="288" y2="110" stroke="#555" stroke-width="1.5" marker-end="url(#arrow)"/>
-
   <rect x="291" y="86" width="70" height="48" rx="8" fill="#f0f4ff" stroke="#2563eb" stroke-width="1.5"/>
   <text x="326" y="114" fill="#1e3a5f" font-size="9" font-weight="600" text-anchor="middle">LLM</text>
-
   <line x1="361" y1="110" x2="375" y2="110" stroke="#555" stroke-width="1.5" marker-end="url(#arrow)"/>
-
   <rect x="378" y="80" width="356" height="60" rx="8" fill="#f0f4ff" stroke="#2563eb" stroke-width="1.5"/>
   <text x="556" y="98" fill="#1e3a5f" font-size="10" font-weight="600" text-anchor="middle">TOOL DISPATCH（コアツールセット）</text>
   <text x="394" y="114" fill="#2563eb" font-size="8">bash · read · write · task(4) · spawn · send · inbox</text>
   <text x="394" y="128" fill="#7c3aed" font-size="8" font-weight="700">★ request_shutdown · request_plan · review_plan</text>
-
-  <!-- Loop back -->
   <path d="M 734 110 L 748 110 L 748 150 L 55 150 L 55 130" fill="none" stroke="#94a3b8" stroke-width="1" marker-end="url(#arrow)" stroke-dasharray="5,4"/>
 
-  <!-- ===== Row 2: Protocol Flow ===== -->
-  <rect x="30" y="176" width="700" height="100" rx="8" fill="#f5f3ff" stroke="#7c3aed" stroke-width="2"/>
-  <text x="380" y="196" fill="#4c1d95" font-size="11" font-weight="700" text-anchor="middle">リクエスト・レスポンスプロトコルフロー（request_id が全チェーンを貫通）</text>
+  <!-- Row 2: shutdown protocol -->
+  <rect x="30" y="176" width="700" height="90" rx="8" fill="#fef3c7" stroke="#d97706" stroke-width="1.5"/>
+  <text x="380" y="196" fill="#92400e" font-size="11" font-weight="700" text-anchor="middle">プロトコル A：shutdown フロー（Lead が開始 → チームメイトが応答）</text>
 
-  <!-- Step 1 -->
-  <rect x="50" y="208" width="130" height="52" rx="6" fill="#fff" stroke="#7c3aed" stroke-width="1"/>
-  <text x="115" y="226" fill="#7c3aed" font-size="9" font-weight="600" text-anchor="middle">① Lead が要求送信</text>
-  <text x="115" y="240" fill="#6b7280" font-size="7" text-anchor="middle">BUS.send("shutdown_request"</text>
-  <text x="115" y="252" fill="#6b7280" font-size="7" text-anchor="middle">metadata={request_id})</text>
+  <rect x="50" y="208" width="180" height="46" rx="6" fill="#fff" stroke="#d97706" stroke-width="1"/>
+  <text x="140" y="226" fill="#92400e" font-size="9" font-weight="600" text-anchor="middle">① Lead: request_shutdown</text>
+  <text x="140" y="242" fill="#6b7280" font-size="7" text-anchor="middle">new_request_id() → ProtocolState</text>
 
-  <line x1="180" y1="234" x2="206" y2="234" stroke="#7c3aed" stroke-width="1.5" marker-end="url(#arrow-purple)"/>
+  <line x1="230" y1="231" x2="254" y2="231" stroke="#d97706" stroke-width="1.5" marker-end="url(#arrow)"/>
 
-  <!-- Step 2 -->
-  <rect x="209" y="208" width="130" height="52" rx="6" fill="#fff" stroke="#7c3aed" stroke-width="1"/>
-  <text x="274" y="226" fill="#7c3aed" font-size="9" font-weight="600" text-anchor="middle">② チームメイト受信</text>
-  <text x="274" y="240" fill="#6b7280" font-size="7" text-anchor="middle">dispatch_by_type(inbox)</text>
-  <text x="274" y="252" fill="#6b7280" font-size="7" text-anchor="middle">→ handler(type, metadata)</text>
+  <rect x="257" y="208" width="180" height="46" rx="6" fill="#fff" stroke="#d97706" stroke-width="1"/>
+  <text x="347" y="226" fill="#92400e" font-size="9" font-weight="600" text-anchor="middle">② チームメイト: handle_shutdown</text>
+  <text x="347" y="242" fill="#6b7280" font-size="7" text-anchor="middle">ack → shutdown_response</text>
 
-  <line x1="339" y1="234" x2="365" y2="234" stroke="#7c3aed" stroke-width="1.5" marker-end="url(#arrow-purple)"/>
+  <line x1="437" y1="231" x2="461" y2="231" stroke="#d97706" stroke-width="1.5" marker-end="url(#arrow)"/>
 
-  <!-- Step 3 -->
-  <rect x="368" y="208" width="130" height="52" rx="6" fill="#fff" stroke="#7c3aed" stroke-width="1"/>
-  <text x="433" y="226" fill="#7c3aed" font-size="9" font-weight="600" text-anchor="middle">③ チームメイト応答</text>
-  <text x="433" y="240" fill="#6b7280" font-size="7" text-anchor="middle">BUS.send("shutdown_response"</text>
-  <text x="433" y="252" fill="#6b7280" font-size="7" text-anchor="middle">同じ request_id + approve)</text>
+  <rect x="464" y="208" width="180" height="46" rx="6" fill="#fff" stroke="#d97706" stroke-width="1"/>
+  <text x="554" y="226" fill="#92400e" font-size="9" font-weight="600" text-anchor="middle">③ Lead: consume_lead_inbox</text>
+  <text x="554" y="242" fill="#6b7280" font-size="7" text-anchor="middle">match_response(request_id) → ✓</text>
 
-  <line x1="498" y1="234" x2="524" y2="234" stroke="#7c3aed" stroke-width="1.5" marker-end="url(#arrow-purple)"/>
+  <!-- Row 3: plan approval protocol -->
+  <rect x="30" y="280" width="700" height="110" rx="8" fill="#dbeafe" stroke="#2563eb" stroke-width="1.5"/>
+  <text x="380" y="300" fill="#1e40af" font-size="11" font-weight="700" text-anchor="middle">プロトコル B：plan approval フロー（チームメイトが開始 → Lead が審査）</text>
 
-  <!-- Step 4 -->
-  <rect x="527" y="208" width="130" height="52" rx="6" fill="#fff" stroke="#7c3aed" stroke-width="1"/>
-  <text x="592" y="226" fill="#7c3aed" font-size="9" font-weight="600" text-anchor="middle">④ Lead 応答受信</text>
-  <text x="592" y="240" fill="#6b7280" font-size="7" text-anchor="middle">match_response(request_id)</text>
-  <text x="592" y="252" fill="#6b7280" font-size="7" text-anchor="middle">→ resolve/reject callback</text>
+  <rect x="50" y="312" width="150" height="46" rx="6" fill="#f1f5f9" stroke="#94a3b8" stroke-width="1"/>
+  <text x="125" y="330" fill="#475569" font-size="8" font-weight="600" text-anchor="middle">0. Lead: request_plan</text>
+  <text x="125" y="346" fill="#6b7280" font-size="7" text-anchor="middle">通常メッセージ（msg_type="message"）</text>
 
-  <!-- ===== Row 3: State Machine + Storage ===== -->
-  <rect x="30" y="296" width="340" height="85" rx="8" fill="#f5f3ff" stroke="#7c3aed" stroke-width="1.5"/>
-  <text x="200" y="316" fill="#4c1d95" font-size="10" font-weight="700" text-anchor="middle">状態機械（2 つのプロトコルで共通）</text>
+  <line x1="200" y1="335" x2="222" y2="335" stroke="#94a3b8" stroke-width="1" marker-end="url(#arrow)" stroke-dasharray="4,3"/>
 
-  <rect x="55" y="330" width="58" height="20" rx="4" fill="#f1f5f9" stroke="#94a3b8" stroke-width="1"/>
-  <text x="84" y="344" fill="#475569" font-size="9" text-anchor="middle">pending</text>
+  <rect x="225" y="312" width="160" height="46" rx="6" fill="#fff" stroke="#2563eb" stroke-width="1"/>
+  <text x="305" y="330" fill="#1e40af" font-size="8" font-weight="600" text-anchor="middle">① チームメイト: submit_plan</text>
+  <text x="305" y="346" fill="#6b7280" font-size="7" text-anchor="middle">plan_approval_request + request_id</text>
 
-  <line x1="113" y1="340" x2="192" y2="340" stroke="#16a34a" stroke-width="1.5" marker-end="url(#arrow-green)"/>
-  <text x="152" y="335" fill="#16a34a" font-size="8" font-weight="600" text-anchor="middle">approve</text>
+  <line x1="385" y1="335" x2="407" y2="335" stroke="#2563eb" stroke-width="1.5" marker-end="url(#arrow)"/>
 
-  <rect x="192" y="330" width="62" height="20" rx="4" fill="#dcfce7" stroke="#16a34a" stroke-width="1"/>
-  <text x="223" y="344" fill="#166534" font-size="9" text-anchor="middle">approved</text>
+  <rect x="410" y="312" width="160" height="46" rx="6" fill="#fff" stroke="#2563eb" stroke-width="1"/>
+  <text x="490" y="330" fill="#1e40af" font-size="8" font-weight="600" text-anchor="middle">② Lead: review_plan</text>
+  <text x="490" y="346" fill="#6b7280" font-size="7" text-anchor="middle">plan_approval_response</text>
 
-  <path d="M 84 350 L 84 368 L 128 368" fill="none" stroke="#dc2626" stroke-width="1.5" marker-end="url(#arrow-red)"/>
-  <text x="76" y="362" fill="#dc2626" font-size="8" font-weight="600" text-anchor="end">reject</text>
+  <line x1="570" y1="335" x2="592" y2="335" stroke="#2563eb" stroke-width="1.5" marker-end="url(#arrow)"/>
 
-  <rect x="128" y="358" width="60" height="20" rx="4" fill="#fef2f2" stroke="#dc2626" stroke-width="1"/>
-  <text x="158" y="372" fill="#991b1b" font-size="9" text-anchor="middle">rejected</text>
+  <rect x="595" y="312" width="120" height="46" rx="6" fill="#fff" stroke="#2563eb" stroke-width="1"/>
+  <text x="655" y="330" fill="#1e40af" font-size="8" font-weight="600" text-anchor="middle">③ チームメイト: 受信</text>
+  <text x="655" y="346" fill="#6b7280" font-size="7" text-anchor="middle">[Plan approved/rejected]</text>
 
-  <rect x="400" y="296" width="330" height="85" rx="8" fill="#f5f3ff" stroke="#7c3aed" stroke-width="1.5"/>
-  <text x="565" y="316" fill="#4c1d95" font-size="10" font-weight="700" text-anchor="middle">pending_requests ストレージ</text>
-  <text x="420" y="336" fill="#7c3aed" font-size="9">pending_requests: dict[str, ProtocolState]</text>
-  <text x="420" y="352" fill="#6b7280" font-size="8">request_id → {type, sender, status, created_at}</text>
-  <text x="420" y="368" fill="#6b7280" font-size="8">match_response: request_id で要求を検索</text>
+  <text x="380" y="380" fill="#6b7280" font-size="8" text-anchor="middle">request_plan は通常メッセージでプロトコルではない。submit_plan がプロトコルエントリポイント（チームメイト側で ProtocolState を作成）</text>
 
-  <!-- ===== Row 4 ===== -->
-  <rect x="30" y="396" width="700" height="48" rx="6" fill="#f8fafc" stroke="#e2e8f0" stroke-width="1"/>
-  <text x="55" y="416" fill="#1e3a5f" font-size="10" font-weight="600">2 つのプロトコル、1 つの仕組み：</text>
-  <rect x="230" y="406" width="130" height="18" rx="4" fill="#fef3c7" stroke="#d97706" stroke-width="1"/>
-  <text x="295" y="419" fill="#92400e" font-size="9" text-anchor="middle">shutdown_request</text>
-  <text x="368" y="419" fill="#475569" font-size="10">と</text>
-  <rect x="390" y="406" width="140" height="18" rx="4" fill="#dbeafe" stroke="#2563eb" stroke-width="1"/>
-  <text x="460" y="419" fill="#1e40af" font-size="9" text-anchor="middle">plan_approval_request</text>
-  <text x="540" y="419" fill="#475569" font-size="10">が pending→approved/rejected 状態機械を共有</text>
-  <text x="55" y="436" fill="#6b7280" font-size="8">新しいプロトコルタイプ = 新しい msg_type、新しい状態機械は不要。request_id が要求と応答を紐付け。</text>
+  <!-- Row 4: State Machine + Storage -->
+  <rect x="30" y="406" width="340" height="85" rx="8" fill="#f5f3ff" stroke="#7c3aed" stroke-width="1.5"/>
+  <text x="200" y="426" fill="#4c1d95" font-size="10" font-weight="700" text-anchor="middle">状態機械（両プロトコルで共用）</text>
 
-  <!-- ===== Bottom notes ===== -->
-  <rect x="30" y="460" width="700" height="28" rx="6" fill="#f8fafc" stroke="#e2e8f0" stroke-width="1"/>
-  <rect x="50" y="470" width="12" height="10" rx="2" fill="#f0f4ff" stroke="#2563eb" stroke-width="1"/>
-  <text x="70" y="480" fill="#475569" font-size="10">s15: MessageBus + spawn_teammate + inbox</text>
-  <rect x="310" y="470" width="12" height="10" rx="2" fill="#f5f3ff" stroke="#7c3aed" stroke-width="1"/>
-  <text x="330" y="480" fill="#475569" font-size="10">s16: request_id プロトコル + dispatch + pending_requests + 状態機械</text>
+  <rect x="55" y="440" width="58" height="20" rx="4" fill="#f1f5f9" stroke="#94a3b8" stroke-width="1"/>
+  <text x="84" y="454" fill="#475569" font-size="9" text-anchor="middle">pending</text>
+  <line x1="113" y1="450" x2="192" y2="450" stroke="#16a34a" stroke-width="1.5" marker-end="url(#arrow-green)"/>
+  <text x="152" y="445" fill="#16a34a" font-size="8" font-weight="600" text-anchor="middle">approve</text>
+  <rect x="192" y="440" width="62" height="20" rx="4" fill="#dcfce7" stroke="#16a34a" stroke-width="1"/>
+  <text x="223" y="454" fill="#166534" font-size="9" text-anchor="middle">approved</text>
+  <path d="M 84 460 L 84 478 L 128 478" fill="none" stroke="#dc2626" stroke-width="1.5" marker-end="url(#arrow-red)"/>
+  <text x="76" y="472" fill="#dc2626" font-size="8" font-weight="600" text-anchor="end">reject</text>
+  <rect x="128" y="468" width="60" height="20" rx="4" fill="#fef2f2" stroke="#dc2626" stroke-width="1"/>
+  <text x="158" y="482" fill="#991b1b" font-size="9" text-anchor="middle">rejected</text>
+
+  <rect x="400" y="406" width="330" height="85" rx="8" fill="#f5f3ff" stroke="#7c3aed" stroke-width="1.5"/>
+  <text x="565" y="426" fill="#4c1d95" font-size="10" font-weight="700" text-anchor="middle">pending_requests ストレージ</text>
+  <text x="420" y="446" fill="#7c3aed" font-size="9">pending_requests: dict[str, ProtocolState]</text>
+  <text x="420" y="462" fill="#6b7280" font-size="8">request_id → {type, sender, status, created_at}</text>
+  <text x="420" y="478" fill="#6b7280" font-size="8">match_response: request_id でリクエストを検索</text>
+
+  <!-- Row 5: Two protocols same machine -->
+  <rect x="30" y="506" width="700" height="52" rx="6" fill="#f8fafc" stroke="#e2e8f0" stroke-width="1"/>
+  <text x="55" y="524" fill="#1e3a5f" font-size="10" font-weight="600">2つのプロトコル、1つのメカニズム：</text>
+  <rect x="270" y="512" width="130" height="18" rx="4" fill="#fef3c7" stroke="#d97706" stroke-width="1"/>
+  <text x="335" y="525" fill="#92400e" font-size="9" text-anchor="middle">shutdown_request</text>
+  <text x="408" y="525" fill="#475569" font-size="10">と</text>
+  <rect x="425" y="512" width="140" height="18" rx="4" fill="#dbeafe" stroke="#2563eb" stroke-width="1"/>
+  <text x="495" y="525" fill="#1e40af" font-size="9" text-anchor="middle">plan_approval_request</text>
+  <text x="55" y="548" fill="#6b7280" font-size="8">同じ pending → approved / rejected 状態機械を共有。新しいプロトコルタイプ = 新しい msg_type、新しい状態機械は不要。request_id がリクエストとレスポンスを関連付ける。</text>
+
+  <!-- Row 6: distinguish -->
+  <rect x="30" y="570" width="700" height="38" rx="6" fill="#f0fdf4" stroke="#16a34a" stroke-width="1"/>
+  <text x="55" y="588" fill="#166534" font-size="9" font-weight="600">区別：</text>
+  <text x="100" y="588" fill="#475569" font-size="9">request_plan は通常メッセージ（msg_type="message"）で、lead がチームメイトに計画提出を促すために送信する。</text>
+  <text x="55" y="602" fill="#475569" font-size="9">submit_plan がプロトコルエントリポイント（msg_type="plan_approval_request"）で、チームメイトが自発的に開始し、request_id を pending_requests に書き込む。</text>
+
+  <!-- Bottom notes -->
+  <rect x="30" y="622" width="700" height="28" rx="6" fill="#f8fafc" stroke="#e2e8f0" stroke-width="1"/>
+  <rect x="50" y="632" width="12" height="10" rx="2" fill="#f0f4ff" stroke="#2563eb" stroke-width="1"/>
+  <text x="70" y="642" fill="#475569" font-size="10">s15: MessageBus + spawn_teammate + inbox</text>
+  <rect x="310" y="632" width="12" height="10" rx="2" fill="#f5f3ff" stroke="#7c3aed" stroke-width="1"/>
+  <text x="330" y="642" fill="#475569" font-size="10">s16: request_id プロトコル + dispatch + pending_requests + 状態機械</text>
 </svg>

--- a/s16_team_protocols/images/team-protocols-overview.svg
+++ b/s16_team_protocols/images/team-protocols-overview.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 760 500" font-family="system-ui, -apple-system, sans-serif">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 760 660" font-family="system-ui, -apple-system, sans-serif">
   <defs>
     <linearGradient id="header" x1="0" y1="0" x2="1" y2="0">
       <stop offset="0%" stop-color="#1e3a5f"/><stop offset="100%" stop-color="#7c3aed"/>
@@ -9,9 +9,6 @@
     <marker id="arrow-purple" viewBox="0 0 10 10" refX="10" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
       <path d="M 0 0 L 10 5 L 0 10 z" fill="#7c3aed"/>
     </marker>
-    <marker id="arrow-cyan" viewBox="0 0 10 10" refX="10" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
-      <path d="M 0 0 L 10 5 L 0 10 z" fill="#0891b2"/>
-    </marker>
     <marker id="arrow-green" viewBox="0 0 10 10" refX="10" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
       <path d="M 0 0 L 10 5 L 0 10 z" fill="#16a34a"/>
     </marker>
@@ -20,129 +17,125 @@
     </marker>
   </defs>
 
-  <rect width="760" height="500" fill="#fafbfc" rx="8"/>
+  <rect width="760" height="660" fill="#fafbfc" rx="8"/>
 
-  <!-- Title -->
   <rect x="0" y="0" width="760" height="44" fill="url(#header)" rx="8"/>
   <rect x="0" y="36" width="760" height="8" fill="url(#header)"/>
   <text x="380" y="28" fill="#fff" font-size="15" font-weight="700" text-anchor="middle">Team Protocols — 请求-响应协议 + request_id 关联 + 状态机</text>
 
-  <!-- Legend -->
   <rect x="40" y="56" width="12" height="10" rx="2" fill="#f0f4ff" stroke="#2563eb" stroke-width="1"/>
   <text x="58" y="66" fill="#2563eb" font-size="10" font-weight="600">s15 保留</text>
   <rect x="140" y="56" width="12" height="10" rx="2" fill="#f5f3ff" stroke="#7c3aed" stroke-width="1"/>
   <text x="158" y="66" fill="#7c3aed" font-size="10" font-weight="600">s16 新增</text>
 
-  <!-- ===== Row 1: Lead Loop ===== -->
+  <!-- Row 1: Lead Loop -->
   <rect x="20" y="90" width="70" height="40" rx="8" fill="#eef2ff" stroke="#4f46e5" stroke-width="1.5"/>
   <text x="55" y="114" fill="#4f46e5" font-size="8" font-weight="600" text-anchor="middle">turn</text>
-
   <line x1="90" y1="110" x2="104" y2="110" stroke="#555" stroke-width="1.5" marker-end="url(#arrow)"/>
-
   <rect x="107" y="90" width="70" height="40" rx="8" fill="#f0f4ff" stroke="#2563eb" stroke-width="1.5"/>
   <text x="142" y="114" fill="#1e3a5f" font-size="10" font-weight="600" text-anchor="middle">messages</text>
-
   <line x1="177" y1="110" x2="191" y2="110" stroke="#555" stroke-width="1.5" marker-end="url(#arrow)"/>
-
   <rect x="194" y="86" width="80" height="48" rx="8" fill="#f0f4ff" stroke="#2563eb" stroke-width="1.5"/>
   <text x="234" y="114" fill="#1e3a5f" font-size="9" font-weight="600" text-anchor="middle">prompt</text>
-
   <line x1="274" y1="110" x2="288" y2="110" stroke="#555" stroke-width="1.5" marker-end="url(#arrow)"/>
-
   <rect x="291" y="86" width="70" height="48" rx="8" fill="#f0f4ff" stroke="#2563eb" stroke-width="1.5"/>
   <text x="326" y="114" fill="#1e3a5f" font-size="9" font-weight="600" text-anchor="middle">LLM</text>
-
   <line x1="361" y1="110" x2="375" y2="110" stroke="#555" stroke-width="1.5" marker-end="url(#arrow)"/>
-
   <rect x="378" y="80" width="356" height="60" rx="8" fill="#f0f4ff" stroke="#2563eb" stroke-width="1.5"/>
   <text x="556" y="98" fill="#1e3a5f" font-size="10" font-weight="600" text-anchor="middle">TOOL DISPATCH（核心工具集）</text>
   <text x="394" y="114" fill="#2563eb" font-size="8">bash · read · write · task(4) · spawn · send · inbox</text>
   <text x="394" y="128" fill="#7c3aed" font-size="8" font-weight="700">★ request_shutdown · request_plan · review_plan</text>
-
-  <!-- Loop back -->
   <path d="M 734 110 L 748 110 L 748 150 L 55 150 L 55 130" fill="none" stroke="#94a3b8" stroke-width="1" marker-end="url(#arrow)" stroke-dasharray="5,4"/>
 
-  <!-- ===== Row 2: Protocol Flow (purple) — request_id lifecycle ===== -->
-  <rect x="30" y="176" width="700" height="100" rx="8" fill="#f5f3ff" stroke="#7c3aed" stroke-width="2"/>
-  <text x="380" y="196" fill="#4c1d95" font-size="11" font-weight="700" text-anchor="middle">请求-响应协议流程（request_id 贯穿）</text>
+  <!-- Row 2: shutdown protocol -->
+  <rect x="30" y="176" width="700" height="90" rx="8" fill="#fef3c7" stroke="#d97706" stroke-width="1.5"/>
+  <text x="380" y="196" fill="#92400e" font-size="11" font-weight="700" text-anchor="middle">协议 A：shutdown 流程（Lead 发起 → 队友响应）</text>
 
-  <!-- Step 1: Send request -->
-  <rect x="50" y="208" width="130" height="52" rx="6" fill="#fff" stroke="#7c3aed" stroke-width="1"/>
-  <text x="115" y="226" fill="#7c3aed" font-size="9" font-weight="600" text-anchor="middle">① Lead 发请求</text>
-  <text x="115" y="240" fill="#6b7280" font-size="7" text-anchor="middle">BUS.send("shutdown_request"</text>
-  <text x="115" y="252" fill="#6b7280" font-size="7" text-anchor="middle">metadata={request_id})</text>
+  <rect x="50" y="208" width="180" height="46" rx="6" fill="#fff" stroke="#d97706" stroke-width="1"/>
+  <text x="140" y="226" fill="#92400e" font-size="9" font-weight="600" text-anchor="middle">① Lead: request_shutdown</text>
+  <text x="140" y="242" fill="#6b7280" font-size="7" text-anchor="middle">new_request_id() → ProtocolState</text>
 
-  <line x1="180" y1="234" x2="206" y2="234" stroke="#7c3aed" stroke-width="1.5" marker-end="url(#arrow-purple)"/>
+  <line x1="230" y1="231" x2="254" y2="231" stroke="#d97706" stroke-width="1.5" marker-end="url(#arrow)"/>
 
-  <!-- Step 2: Teammate receives & dispatches -->
-  <rect x="209" y="208" width="130" height="52" rx="6" fill="#fff" stroke="#7c3aed" stroke-width="1"/>
-  <text x="274" y="226" fill="#7c3aed" font-size="9" font-weight="600" text-anchor="middle">② 队友收到</text>
-  <text x="274" y="240" fill="#6b7280" font-size="7" text-anchor="middle">dispatch_by_type(inbox)</text>
-  <text x="274" y="252" fill="#6b7280" font-size="7" text-anchor="middle">→ handler(type, metadata)</text>
+  <rect x="257" y="208" width="180" height="46" rx="6" fill="#fff" stroke="#d97706" stroke-width="1"/>
+  <text x="347" y="226" fill="#92400e" font-size="9" font-weight="600" text-anchor="middle">② 队友: handle_shutdown</text>
+  <text x="347" y="242" fill="#6b7280" font-size="7" text-anchor="middle">ack → shutdown_response</text>
 
-  <line x1="339" y1="234" x2="365" y2="234" stroke="#7c3aed" stroke-width="1.5" marker-end="url(#arrow-purple)"/>
+  <line x1="437" y1="231" x2="461" y2="231" stroke="#d97706" stroke-width="1.5" marker-end="url(#arrow)"/>
 
-  <!-- Step 3: Teammate processes & responds -->
-  <rect x="368" y="208" width="130" height="52" rx="6" fill="#fff" stroke="#7c3aed" stroke-width="1"/>
-  <text x="433" y="226" fill="#7c3aed" font-size="9" font-weight="600" text-anchor="middle">③ 队友回复</text>
-  <text x="433" y="240" fill="#6b7280" font-size="7" text-anchor="middle">BUS.send("shutdown_response"</text>
-  <text x="433" y="252" fill="#6b7280" font-size="7" text-anchor="middle">同 request_id + approve)</text>
+  <rect x="464" y="208" width="180" height="46" rx="6" fill="#fff" stroke="#d97706" stroke-width="1"/>
+  <text x="554" y="226" fill="#92400e" font-size="9" font-weight="600" text-anchor="middle">③ Lead: consume_lead_inbox</text>
+  <text x="554" y="242" fill="#6b7280" font-size="7" text-anchor="middle">match_response(request_id) → ✓</text>
 
-  <line x1="498" y1="234" x2="524" y2="234" stroke="#7c3aed" stroke-width="1.5" marker-end="url(#arrow-purple)"/>
+  <!-- Row 3: plan approval protocol -->
+  <rect x="30" y="280" width="700" height="110" rx="8" fill="#dbeafe" stroke="#2563eb" stroke-width="1.5"/>
+  <text x="380" y="300" fill="#1e40af" font-size="11" font-weight="700" text-anchor="middle">协议 B：plan approval 流程（队友发起 → Lead 审批）</text>
 
-  <!-- Step 4: Lead receives response -->
-  <rect x="527" y="208" width="130" height="52" rx="6" fill="#fff" stroke="#7c3aed" stroke-width="1"/>
-  <text x="592" y="226" fill="#7c3aed" font-size="9" font-weight="600" text-anchor="middle">④ Lead 收响应</text>
-  <text x="592" y="240" fill="#6b7280" font-size="7" text-anchor="middle">match_response(request_id)</text>
-  <text x="592" y="252" fill="#6b7280" font-size="7" text-anchor="middle">→ resolve/reject callback</text>
+  <rect x="50" y="312" width="150" height="46" rx="6" fill="#f1f5f9" stroke="#94a3b8" stroke-width="1"/>
+  <text x="125" y="330" fill="#475569" font-size="8" font-weight="600" text-anchor="middle">0. Lead: request_plan</text>
+  <text x="125" y="346" fill="#6b7280" font-size="7" text-anchor="middle">普通消息（msg_type="message"）</text>
 
-  <!-- ===== Row 3: State Machine + Storage ===== -->
-  <!-- State Machine -->
-  <rect x="30" y="296" width="340" height="85" rx="8" fill="#f5f3ff" stroke="#7c3aed" stroke-width="1.5"/>
-  <text x="200" y="316" fill="#4c1d95" font-size="10" font-weight="700" text-anchor="middle">状态机（同一套，两种协议）</text>
+  <line x1="200" y1="335" x2="222" y2="335" stroke="#94a3b8" stroke-width="1" marker-end="url(#arrow)" stroke-dasharray="4,3"/>
 
-  <!-- pending box: center (84, 340), right edge x=113, bottom y=350 -->
-  <rect x="55" y="330" width="58" height="20" rx="4" fill="#f1f5f9" stroke="#94a3b8" stroke-width="1"/>
-  <text x="84" y="344" fill="#475569" font-size="9" text-anchor="middle">pending</text>
+  <rect x="225" y="312" width="160" height="46" rx="6" fill="#fff" stroke="#2563eb" stroke-width="1"/>
+  <text x="305" y="330" fill="#1e40af" font-size="8" font-weight="600" text-anchor="middle">① 队友: submit_plan</text>
+  <text x="305" y="346" fill="#6b7280" font-size="7" text-anchor="middle">plan_approval_request + request_id</text>
 
-  <!-- approve: line from pending right (113,340) to approved left (192,340) -->
-  <line x1="113" y1="340" x2="192" y2="340" stroke="#16a34a" stroke-width="1.5" marker-end="url(#arrow-green)"/>
-  <text x="152" y="335" fill="#16a34a" font-size="8" font-weight="600" text-anchor="middle">approve</text>
+  <line x1="385" y1="335" x2="407" y2="335" stroke="#2563eb" stroke-width="1.5" marker-end="url(#arrow)"/>
 
-  <!-- approved box: left edge x=192 -->
-  <rect x="192" y="330" width="62" height="20" rx="4" fill="#dcfce7" stroke="#16a34a" stroke-width="1"/>
-  <text x="223" y="344" fill="#166534" font-size="9" text-anchor="middle">approved</text>
+  <rect x="410" y="312" width="160" height="46" rx="6" fill="#fff" stroke="#2563eb" stroke-width="1"/>
+  <text x="490" y="330" fill="#1e40af" font-size="8" font-weight="600" text-anchor="middle">② Lead: review_plan</text>
+  <text x="490" y="346" fill="#6b7280" font-size="7" text-anchor="middle">plan_approval_response</text>
 
-  <!-- reject: path from pending bottom (84,350) down to (84,368) then right to rejected left (128,368) -->
-  <path d="M 84 350 L 84 368 L 128 368" fill="none" stroke="#dc2626" stroke-width="1.5" marker-end="url(#arrow-red)"/>
-  <text x="76" y="362" fill="#dc2626" font-size="8" font-weight="600" text-anchor="end">reject</text>
+  <line x1="570" y1="335" x2="592" y2="335" stroke="#2563eb" stroke-width="1.5" marker-end="url(#arrow)"/>
 
-  <!-- rejected box: left edge x=128, top y=358 -->
-  <rect x="128" y="358" width="60" height="20" rx="4" fill="#fef2f2" stroke="#dc2626" stroke-width="1"/>
-  <text x="158" y="372" fill="#991b1b" font-size="9" text-anchor="middle">rejected</text>
+  <rect x="595" y="312" width="120" height="46" rx="6" fill="#fff" stroke="#2563eb" stroke-width="1"/>
+  <text x="655" y="330" fill="#1e40af" font-size="8" font-weight="600" text-anchor="middle">③ 队友: 收到结果</text>
+  <text x="655" y="346" fill="#6b7280" font-size="7" text-anchor="middle">[Plan approved/rejected]</text>
 
-  <!-- pending_requests storage -->
-  <rect x="400" y="296" width="330" height="85" rx="8" fill="#f5f3ff" stroke="#7c3aed" stroke-width="1.5"/>
-  <text x="565" y="316" fill="#4c1d95" font-size="10" font-weight="700" text-anchor="middle">pending_requests 存储</text>
-  <text x="420" y="336" fill="#7c3aed" font-size="9">pending_requests: dict[str, ProtocolState]</text>
-  <text x="420" y="352" fill="#6b7280" font-size="8">request_id → {type, sender, status, created_at}</text>
-  <text x="420" y="368" fill="#6b7280" font-size="8">match_response: 按 request_id 找回对应请求</text>
+  <text x="380" y="380" fill="#6b7280" font-size="8" text-anchor="middle">request_plan 是普通消息不是协议；submit_plan 才是协议入口（由队友端创建 ProtocolState）</text>
 
-  <!-- ===== Row 4: Two protocols use same machine ===== -->
-  <rect x="30" y="396" width="700" height="48" rx="6" fill="#f8fafc" stroke="#e2e8f0" stroke-width="1"/>
-  <text x="55" y="416" fill="#1e3a5f" font-size="10" font-weight="600">两种协议，同一套机制：</text>
-  <rect x="230" y="406" width="130" height="18" rx="4" fill="#fef3c7" stroke="#d97706" stroke-width="1"/>
-  <text x="295" y="419" fill="#92400e" font-size="9" text-anchor="middle">shutdown_request</text>
-  <text x="368" y="419" fill="#475569" font-size="10">和</text>
-  <rect x="390" y="406" width="140" height="18" rx="4" fill="#dbeafe" stroke="#2563eb" stroke-width="1"/>
-  <text x="460" y="419" fill="#1e40af" font-size="9" text-anchor="middle">plan_approval_request</text>
-  <text x="540" y="419" fill="#475569" font-size="10">共用 pending→approved/rejected 状态机</text>
-  <text x="55" y="436" fill="#6b7280" font-size="8">新增协议类型 = 新的 msg_type，不需要新状态机。request_id 关联请求和响应。</text>
+  <!-- Row 4: State Machine + Storage -->
+  <rect x="30" y="406" width="340" height="85" rx="8" fill="#f5f3ff" stroke="#7c3aed" stroke-width="1.5"/>
+  <text x="200" y="426" fill="#4c1d95" font-size="10" font-weight="700" text-anchor="middle">状态机（同一套，两种协议共用）</text>
 
-  <!-- ===== Bottom notes ===== -->
-  <rect x="30" y="460" width="700" height="28" rx="6" fill="#f8fafc" stroke="#e2e8f0" stroke-width="1"/>
-  <rect x="50" y="470" width="12" height="10" rx="2" fill="#f0f4ff" stroke="#2563eb" stroke-width="1"/>
-  <text x="70" y="480" fill="#475569" font-size="10">s15: MessageBus + spawn_teammate + inbox</text>
-  <rect x="310" y="470" width="12" height="10" rx="2" fill="#f5f3ff" stroke="#7c3aed" stroke-width="1"/>
-  <text x="330" y="480" fill="#475569" font-size="10">s16: request_id 协议 + dispatch + pending_requests + 状态机</text>
+  <rect x="55" y="440" width="58" height="20" rx="4" fill="#f1f5f9" stroke="#94a3b8" stroke-width="1"/>
+  <text x="84" y="454" fill="#475569" font-size="9" text-anchor="middle">pending</text>
+  <line x1="113" y1="450" x2="192" y2="450" stroke="#16a34a" stroke-width="1.5" marker-end="url(#arrow-green)"/>
+  <text x="152" y="445" fill="#16a34a" font-size="8" font-weight="600" text-anchor="middle">approve</text>
+  <rect x="192" y="440" width="62" height="20" rx="4" fill="#dcfce7" stroke="#16a34a" stroke-width="1"/>
+  <text x="223" y="454" fill="#166534" font-size="9" text-anchor="middle">approved</text>
+  <path d="M 84 460 L 84 478 L 128 478" fill="none" stroke="#dc2626" stroke-width="1.5" marker-end="url(#arrow-red)"/>
+  <text x="76" y="472" fill="#dc2626" font-size="8" font-weight="600" text-anchor="end">reject</text>
+  <rect x="128" y="468" width="60" height="20" rx="4" fill="#fef2f2" stroke="#dc2626" stroke-width="1"/>
+  <text x="158" y="482" fill="#991b1b" font-size="9" text-anchor="middle">rejected</text>
+
+  <rect x="400" y="406" width="330" height="85" rx="8" fill="#f5f3ff" stroke="#7c3aed" stroke-width="1.5"/>
+  <text x="565" y="426" fill="#4c1d95" font-size="10" font-weight="700" text-anchor="middle">pending_requests 存储</text>
+  <text x="420" y="446" fill="#7c3aed" font-size="9">pending_requests: dict[str, ProtocolState]</text>
+  <text x="420" y="462" fill="#6b7280" font-size="8">request_id → {type, sender, status, created_at}</text>
+  <text x="420" y="478" fill="#6b7280" font-size="8">match_response: 按 request_id 找回对应请求</text>
+
+  <!-- Row 5: Two protocols same machine -->
+  <rect x="30" y="506" width="700" height="52" rx="6" fill="#f8fafc" stroke="#e2e8f0" stroke-width="1"/>
+  <text x="55" y="524" fill="#1e3a5f" font-size="10" font-weight="600">两种协议，同一套机制：</text>
+  <rect x="230" y="512" width="130" height="18" rx="4" fill="#fef3c7" stroke="#d97706" stroke-width="1"/>
+  <text x="295" y="525" fill="#92400e" font-size="9" text-anchor="middle">shutdown_request</text>
+  <text x="368" y="525" fill="#475569" font-size="10">和</text>
+  <rect x="390" y="512" width="140" height="18" rx="4" fill="#dbeafe" stroke="#2563eb" stroke-width="1"/>
+  <text x="460" y="525" fill="#1e40af" font-size="9" text-anchor="middle">plan_approval_request</text>
+  <text x="55" y="548" fill="#6b7280" font-size="8">共用 pending → approved / rejected 状态机。新增协议类型 = 新的 msg_type，不需要新状态机。request_id 关联请求和响应。</text>
+
+  <!-- Row 6: distinguish -->
+  <rect x="30" y="570" width="700" height="38" rx="6" fill="#f0fdf4" stroke="#16a34a" stroke-width="1"/>
+  <text x="55" y="588" fill="#166534" font-size="9" font-weight="600">区分：</text>
+  <text x="100" y="588" fill="#475569" font-size="9">request_plan 是普通消息（msg_type="message"），由 lead 发送给队友提示去提交计划。</text>
+  <text x="55" y="602" fill="#475569" font-size="9">submit_plan 才是协议入口（msg_type="plan_approval_request"），由队友主动发起，携带 request_id 写入 pending_requests。</text>
+
+  <!-- Bottom notes -->
+  <rect x="30" y="622" width="700" height="28" rx="6" fill="#f8fafc" stroke="#e2e8f0" stroke-width="1"/>
+  <rect x="50" y="632" width="12" height="10" rx="2" fill="#f0f4ff" stroke="#2563eb" stroke-width="1"/>
+  <text x="70" y="642" fill="#475569" font-size="10">s15: MessageBus + spawn_teammate + inbox</text>
+  <rect x="310" y="632" width="12" height="10" rx="2" fill="#f5f3ff" stroke="#7c3aed" stroke-width="1"/>
+  <text x="330" y="642" fill="#475569" font-size="10">s16: request_id 协议 + dispatch + pending_requests + 状态机</text>
 </svg>


### PR DESCRIPTION
Split the single protocol row in the flowchart into two distinct flows:

- Protocol A (yellow): shutdown flow, initiated by Lead via request_shutdown
- Protocol B (blue): plan approval flow, initiated by Teammate via submit_plan

request_plan is now correctly shown as a plain message (grey dashed box and arrow), not a protocol action. review_plan is added to the diagram. All three language SVGs updated.

Closes #373.
