### PR TITLE
Clarify tool call request wording

### DIFF
--- a/s01_agent_loop/README.en.md
+++ b/s01_agent_loop/README.en.md
@@ -53,7 +53,7 @@ response = client.messages.create(
 )
 ```
 
-**Step 3**: Append the model's response and check whether it called a tool. No tool call → done.
+**Step 3**: Append the model's response and check whether it requested a tool call. No request → done.
 
 ```python
 messages.append({"role": "assistant", "content": response.content})

--- a/s01_agent_loop/README.ja.md
+++ b/s01_agent_loop/README.ja.md
@@ -53,7 +53,7 @@ response = client.messages.create(
 )
 ```
 
-**ステップ 3**：モデルの応答を追加し、ツールを呼び出したか確認する。呼び出しなし → 終了。
+**ステップ 3**：モデルの応答を追加し、ツール呼び出しを要求したか確認する。要求なし → 終了。
 
 ```python
 messages.append({"role": "assistant", "content": response.content})

--- a/s01_agent_loop/README.md
+++ b/s01_agent_loop/README.md
@@ -53,7 +53,7 @@ response = client.messages.create(
 )
 ```
 
-**第 3 步**：追加模型回答，检查它是否调了工具。没调 → 结束。
+**第 3 步**：追加模型回答，检查模型是否请求调用工具。没请求 → 结束。
 
 ```python
 messages.append({"role": "assistant", "content": response.content})


### PR DESCRIPTION
  Clarifies Step 3 in the s01 agent loop docs.

  In this step, the model has only returned a `tool_use` request in its assistant response. The harness does not execute the tool until Step 4, where it reads that request and calls `run_bash(...)`.

  This changes “called a tool” to “requested a tool call” across the three s01 README language versions.
