### PR TITLE
fix(s08): append tool_result before compact_history to avoid tool_use…

### DIFF
--- a/s08_context_compact/code.py
+++ b/s08_context_compact/code.py
@@ -486,10 +486,13 @@ def agent_loop(messages: list):
 
             # s08: compact tool triggers compact_history, not a no-op string
             if block.name == "compact":
-                messages[:] = compact_history(messages)
+                # Append tool_result BEFORE compact_history so the tool_use/tool_result
+                # pair remains intact; compact_history would otherwise drop the assistant
+                # message containing block.id, causing a 400 BadRequestError.
                 results.append({"type": "tool_result", "tool_use_id": block.id,
                                 "content": "[Compacted. Conversation history has been summarized.]"})
                 messages.append({"role": "user", "content": results})
+                messages[:] = compact_history(messages)
                 break  # end current turn, start fresh with compacted context
 
             blocked = trigger_hooks("PreToolUse", block)


### PR DESCRIPTION
…_id mismatch

When the model calls the compact tool, compact_history() replaces the entire messages list, discarding the assistant message that contains block.id. Any subsequent tool_result referencing that id triggers a 400 BadRequestError:

  tool_use_id found in tool_result blocks: call_xxx.
  Each tool_result block must have a corresponding tool_use block.

Fix: append the tool_result and user message first, then run compact_history() so the tool_use/tool_result pair is intact before compaction.

Fixes #500