### PR TITLE
fix(s13,s14,s20): report failed background tasks instead of hanging

### DIFF
--- a/s08_context_compact/code.py
+++ b/s08_context_compact/code.py
@@ -431,7 +431,7 @@ def trigger_hooks(event, *args):
         if r is not None: return r
     return None
 
-DENY_LIST = ["rm -rf /", "sudo", "shutdown"]
+DENY_LIST = ["rm -rf /", "sudo", "shutdown", "reboot", "mkfs", "dd if="]
 def permission_hook(block):
     if block.name == "bash":
         for p in DENY_LIST:

--- a/s13_background_tasks/README.en.md
+++ b/s13_background_tasks/README.en.md
@@ -80,9 +80,12 @@ def start_background_task(block) -> str:
     bg_id = f"bg_{_bg_counter:04d}"
 
     def worker():
-        result = execute_tool(block)
+        try:
+            result, status = execute_tool(block), "completed"
+        except Exception as e:
+            result, status = f"Error: {type(e).__name__}: {e}", "failed"
         with background_lock:
-            background_tasks[bg_id]["status"] = "completed"
+            background_tasks[bg_id]["status"] = status
             background_results[bg_id] = result
 
     with background_lock:
@@ -107,7 +110,7 @@ def collect_background_results() -> list[str]:
     """Collect completed results as task_notification messages."""
     with background_lock:
         ready_ids = [bid for bid, task in background_tasks.items()
-                     if task["status"] == "completed"]
+                     if task["status"] != "running"]
     notifications = []
     for bg_id in ready_ids:
         with background_lock:
@@ -116,7 +119,7 @@ def collect_background_results() -> list[str]:
         notifications.append(
             f"<task_notification>\n"
             f"  <task_id>{bg_id}</task_id>\n"
-            f"  <status>completed</status>\n"
+            f"  <status>{task['status']}</status>\n"
             f"  <command>{task['command']}</command>\n"
             f"  <summary>{output[:200]}</summary>\n"
             f"</task_notification>")

--- a/s13_background_tasks/README.ja.md
+++ b/s13_background_tasks/README.ja.md
@@ -80,9 +80,12 @@ def start_background_task(block) -> str:
     bg_id = f"bg_{_bg_counter:04d}"
 
     def worker():
-        result = execute_tool(block)
+        try:
+            result, status = execute_tool(block), "completed"
+        except Exception as e:
+            result, status = f"Error: {type(e).__name__}: {e}", "failed"
         with background_lock:
-            background_tasks[bg_id]["status"] = "completed"
+            background_tasks[bg_id]["status"] = status
             background_results[bg_id] = result
 
     with background_lock:
@@ -107,7 +110,7 @@ def collect_background_results() -> list[str]:
     """Collect completed results as task_notification messages."""
     with background_lock:
         ready_ids = [bid for bid, task in background_tasks.items()
-                     if task["status"] == "completed"]
+                     if task["status"] != "running"]
     notifications = []
     for bg_id in ready_ids:
         with background_lock:
@@ -116,7 +119,7 @@ def collect_background_results() -> list[str]:
         notifications.append(
             f"<task_notification>\n"
             f"  <task_id>{bg_id}</task_id>\n"
-            f"  <status>completed</status>\n"
+            f"  <status>{task['status']}</status>\n"
             f"  <command>{task['command']}</command>\n"
             f"  <summary>{output[:200]}</summary>\n"
             f"</task_notification>")

--- a/s13_background_tasks/README.md
+++ b/s13_background_tasks/README.md
@@ -80,9 +80,12 @@ def start_background_task(block) -> str:
     bg_id = f"bg_{_bg_counter:04d}"
 
     def worker():
-        result = execute_tool(block)
+        try:
+            result, status = execute_tool(block), "completed"
+        except Exception as e:
+            result, status = f"Error: {type(e).__name__}: {e}", "failed"
         with background_lock:
-            background_tasks[bg_id]["status"] = "completed"
+            background_tasks[bg_id]["status"] = status
             background_results[bg_id] = result
 
     with background_lock:
@@ -107,7 +110,7 @@ def collect_background_results() -> list[str]:
     """Collect completed results as task_notification messages."""
     with background_lock:
         ready_ids = [bid for bid, task in background_tasks.items()
-                     if task["status"] == "completed"]
+                     if task["status"] != "running"]
     notifications = []
     for bg_id in ready_ids:
         with background_lock:
@@ -116,7 +119,7 @@ def collect_background_results() -> list[str]:
         notifications.append(
             f"<task_notification>\n"
             f"  <task_id>{bg_id}</task_id>\n"
-            f"  <status>completed</status>\n"
+            f"  <status>{task['status']}</status>\n"
             f"  <command>{task['command']}</command>\n"
             f"  <summary>{output[:200]}</summary>\n"
             f"</task_notification>")

--- a/s13_background_tasks/code.py
+++ b/s13_background_tasks/code.py
@@ -349,9 +349,14 @@ def start_background_task(block) -> str:
     cmd = block.input.get("command", block.name)
 
     def worker():
-        result = execute_tool(block)
+        # A thread that dies on an exception would leave the task stuck in
+        # "running" forever — the model would never hear back about it.
+        try:
+            result, status = execute_tool(block), "completed"
+        except Exception as e:
+            result, status = f"Error: {type(e).__name__}: {e}", "failed"
         with background_lock:
-            background_tasks[bg_id]["status"] = "completed"
+            background_tasks[bg_id]["status"] = status
             background_results[bg_id] = result
 
     with background_lock:
@@ -367,10 +372,10 @@ def start_background_task(block) -> str:
 
 
 def collect_background_results() -> list[str]:
-    """Collect completed background results as task_notification messages."""
+    """Collect finished background results as task_notification messages."""
     with background_lock:
         ready_ids = [bid for bid, task in background_tasks.items()
-                     if task["status"] == "completed"]
+                     if task["status"] != "running"]
     notifications = []
     for bg_id in ready_ids:
         with background_lock:
@@ -380,7 +385,7 @@ def collect_background_results() -> list[str]:
         notifications.append(
             f"<task_notification>\n"
             f"  <task_id>{bg_id}</task_id>\n"
-            f"  <status>completed</status>\n"
+            f"  <status>{task['status']}</status>\n"
             f"  <command>{task['command']}</command>\n"
             f"  <summary>{summary}</summary>\n"
             f"</task_notification>")

--- a/s14_cron_scheduler/code.py
+++ b/s14_cron_scheduler/code.py
@@ -304,9 +304,14 @@ def start_background_task(block) -> str:
     cmd = block.input.get("command", block.name)
 
     def worker():
-        result = execute_tool(block)
+        # A thread that dies on an exception would leave the task stuck in
+        # "running" forever — the model would never hear back about it.
+        try:
+            result, status = execute_tool(block), "completed"
+        except Exception as e:
+            result, status = f"Error: {type(e).__name__}: {e}", "failed"
         with background_lock:
-            background_tasks[bg_id]["status"] = "completed"
+            background_tasks[bg_id]["status"] = status
             background_results[bg_id] = result
 
     with background_lock:
@@ -321,10 +326,10 @@ def start_background_task(block) -> str:
 
 
 def collect_background_results() -> list[str]:
-    """Collect completed background results as task_notification messages."""
+    """Collect finished background results as task_notification messages."""
     with background_lock:
         ready_ids = [bid for bid, task in background_tasks.items()
-                     if task["status"] == "completed"]
+                     if task["status"] != "running"]
     notifications = []
     for bg_id in ready_ids:
         with background_lock:
@@ -334,7 +339,7 @@ def collect_background_results() -> list[str]:
         notifications.append(
             f"<task_notification>\n"
             f"  <task_id>{bg_id}</task_id>\n"
-            f"  <status>completed</status>\n"
+            f"  <status>{task['status']}</status>\n"
             f"  <command>{task['command']}</command>\n"
             f"  <summary>{summary}</summary>\n"
             f"</task_notification>")

--- a/s20_comprehensive/code.py
+++ b/s20_comprehensive/code.py
@@ -1285,11 +1285,17 @@ def start_background_task(block, handlers: dict) -> str:
     command = block.input.get("command", block.name)
 
     def worker():
-        handler = handlers.get(block.name)
-        result = call_tool_handler(handler, block.input, block.name)
-        trigger_hooks("PostToolUse", block, result)
+        # A thread that dies on an exception would leave the task stuck in
+        # "running" forever — the model would never hear back about it.
+        try:
+            handler = handlers.get(block.name)
+            result = call_tool_handler(handler, block.input, block.name)
+            trigger_hooks("PostToolUse", block, result)
+            status = "completed"
+        except Exception as e:
+            result, status = f"Error: {type(e).__name__}: {e}", "failed"
         with background_lock:
-            background_tasks[bg_id]["status"] = "completed"
+            background_tasks[bg_id]["status"] = status
             background_results[bg_id] = str(result)
 
     with background_lock:
@@ -1306,7 +1312,7 @@ def start_background_task(block, handlers: dict) -> str:
 def collect_background_results() -> list[str]:
     with background_lock:
         ready = [bg_id for bg_id, task in background_tasks.items()
-                 if task["status"] == "completed"]
+                 if task["status"] != "running"]
     notifications = []
     for bg_id in ready:
         with background_lock:
@@ -1316,7 +1322,7 @@ def collect_background_results() -> list[str]:
         notifications.append(
             f"<task_notification>\n"
             f"  <task_id>{bg_id}</task_id>\n"
-            f"  <status>completed</status>\n"
+            f"  <status>{task['status']}</status>\n"
             f"  <command>{task['command']}</command>\n"
             f"  <summary>{summary}</summary>\n"
             f"</task_notification>")

--- a/tests/test_background_task_failure.py
+++ b/tests/test_background_task_failure.py
@@ -1,0 +1,146 @@
+import importlib.util
+import os
+import sys
+import tempfile
+import time
+import types
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+MODULES = {
+    "s13": REPO_ROOT / "s13_background_tasks" / "code.py",
+    "s14": REPO_ROOT / "s14_cron_scheduler" / "code.py",
+    "s20": REPO_ROOT / "s20_comprehensive" / "code.py",
+}
+
+
+def load_module(name: str, path: Path, temp_cwd: Path):
+    fake_anthropic = types.ModuleType("anthropic")
+
+    class FakeAnthropic:
+        def __init__(self, *args, **kwargs):
+            self.messages = types.SimpleNamespace(create=None)
+
+    fake_dotenv = types.ModuleType("dotenv")
+    fake_yaml = types.ModuleType("yaml")
+    setattr(fake_anthropic, "Anthropic", FakeAnthropic)
+    setattr(fake_dotenv, "load_dotenv", lambda override=True: None)
+    setattr(fake_yaml, "safe_load", lambda text: {})
+    setattr(fake_yaml, "YAMLError", Exception)
+
+    previous_modules = {
+        "anthropic": sys.modules.get("anthropic"),
+        "dotenv": sys.modules.get("dotenv"),
+        "yaml": sys.modules.get("yaml"),
+    }
+    previous_cwd = Path.cwd()
+    previous_model = os.environ.get("MODEL_ID")
+
+    spec = importlib.util.spec_from_file_location(f"{name}_bg_test", path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Unable to load {path}")
+    module = importlib.util.module_from_spec(spec)
+
+    sys.modules["anthropic"] = fake_anthropic
+    sys.modules["dotenv"] = fake_dotenv
+    sys.modules["yaml"] = fake_yaml
+    try:
+        os.chdir(temp_cwd)
+        os.environ["MODEL_ID"] = "test-model"
+        spec.loader.exec_module(module)
+        return module
+    finally:
+        os.chdir(previous_cwd)
+        if previous_model is None:
+            os.environ.pop("MODEL_ID", None)
+        else:
+            os.environ["MODEL_ID"] = previous_model
+        for mod_name, previous in previous_modules.items():
+            if previous is None:
+                sys.modules.pop(mod_name, None)
+            else:
+                sys.modules[mod_name] = previous
+
+
+def boom(**kwargs):
+    raise RuntimeError("handler exploded")
+
+
+def start_failing_task(module, name: str):
+    """Dispatch a background task whose handler raises, per-module wiring."""
+    block = types.SimpleNamespace(name="bash", input={"command": "boom"}, id="tu_1")
+    if name == "s20":
+        return module.start_background_task(block, {"bash": boom})
+    if name == "s14":
+        # s14 builds its handler table inline from module globals.
+        module.run_bash = boom
+        return module.start_background_task(block)
+    module.TOOL_HANDLERS["bash"] = boom
+    return module.start_background_task(block)
+
+
+def wait_for_terminal_status(module, bg_id: str, timeout: float = 5.0):
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        with module.background_lock:
+            task = module.background_tasks.get(bg_id)
+            status = task["status"] if task else None
+        if status is None or status != "running":
+            return status
+        time.sleep(0.01)
+    return "running"
+
+
+class BackgroundTaskFailureTests(unittest.TestCase):
+    def test_failing_handler_does_not_leave_task_running_forever(self):
+        for name, path in MODULES.items():
+            with self.subTest(module=name), tempfile.TemporaryDirectory() as tmp:
+                module = load_module(name, path, Path(tmp))
+                bg_id = start_failing_task(module, name)
+
+                status = wait_for_terminal_status(module, bg_id)
+                self.assertNotEqual(
+                    status, "running",
+                    f"{name}: background task stayed 'running' after the handler raised")
+
+    def test_failure_is_reported_back_to_the_model(self):
+        for name, path in MODULES.items():
+            with self.subTest(module=name), tempfile.TemporaryDirectory() as tmp:
+                module = load_module(name, path, Path(tmp))
+                bg_id = start_failing_task(module, name)
+                wait_for_terminal_status(module, bg_id)
+
+                notifications = module.collect_background_results()
+                self.assertEqual(
+                    len(notifications), 1,
+                    f"{name}: failed background task produced no notification")
+                self.assertIn("<status>failed</status>", notifications[0])
+                self.assertIn("handler exploded", notifications[0])
+
+    def test_successful_task_still_reports_completed(self):
+        for name, path in MODULES.items():
+            with self.subTest(module=name), tempfile.TemporaryDirectory() as tmp:
+                module = load_module(name, path, Path(tmp))
+                block = types.SimpleNamespace(
+                    name="bash", input={"command": "ok"}, id="tu_2")
+                ok = lambda **kwargs: "all good"
+                if name == "s20":
+                    bg_id = module.start_background_task(block, {"bash": ok})
+                elif name == "s14":
+                    module.run_bash = ok
+                    bg_id = module.start_background_task(block)
+                else:
+                    module.TOOL_HANDLERS["bash"] = ok
+                    bg_id = module.start_background_task(block)
+
+                wait_for_terminal_status(module, bg_id)
+                notifications = module.collect_background_results()
+                self.assertEqual(len(notifications), 1)
+                self.assertIn("<status>completed</status>", notifications[0])
+                self.assertIn("all good", notifications[0])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_deny_list_consistency.py
+++ b/tests/test_deny_list_consistency.py
@@ -1,0 +1,41 @@
+"""s04 introduces the PreToolUse deny list and s05-s08 carry it forward
+unchanged. s08 had silently dropped three entries; this test pins the
+inherited baseline so a copy-forward can't quietly weaken it again."""
+
+import re
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+MODULES = {
+    "s04": REPO_ROOT / "s04_hooks" / "code.py",
+    "s05": REPO_ROOT / "s05_todo_write" / "code.py",
+    "s06": REPO_ROOT / "s06_subagent" / "code.py",
+    "s07": REPO_ROOT / "s07_skill_loading" / "code.py",
+    "s08": REPO_ROOT / "s08_context_compact" / "code.py",
+    "s20": REPO_ROOT / "s20_comprehensive" / "code.py",
+}
+
+BASELINE = {"rm -rf /", "sudo", "shutdown", "reboot", "mkfs", "dd if="}
+
+
+def read_deny_list(path: Path) -> set:
+    match = re.search(r"^DENY_LIST = \[(.*?)\]$", path.read_text(), re.M | re.S)
+    if not match:
+        raise AssertionError(f"No DENY_LIST found in {path}")
+    return set(re.findall(r'"([^"]*)"', match.group(1)))
+
+
+class DenyListConsistencyTests(unittest.TestCase):
+    def test_deny_list_covers_the_s04_baseline(self):
+        for name, path in MODULES.items():
+            with self.subTest(module=name):
+                self.assertTrue(
+                    BASELINE <= read_deny_list(path),
+                    f"{name} DENY_LIST is missing "
+                    f"{sorted(BASELINE - read_deny_list(path))}")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 问题

### 1. 后台任务失败后永远卡在 `running`（s13 / s14 / s20）

`start_background_task` 里的 worker 线程在**没有任何 try/except** 的情况下调用工具 handler：

```python
def worker():
    result = execute_tool(block)          # 抛异常 → 线程直接死掉
    with background_lock:
        background_tasks[bg_id]["status"] = "completed"   # 永远执行不到
        background_results[bg_id] = result
```

handler 一旦抛异常（比如模型给了多余的参数导致 `TypeError`，或 s20 里 `trigger_hooks("PostToolUse", ...)` 抛错），线程在写回状态之前就死了，任务永远停在 `"running"`。而 `collect_background_results` 只挑 `status == "completed"` 的任务，于是：

- 这个任务永远不会被回收，`background_tasks` 里泄漏一条记录；
- 模型收到的是 `[Background task bg_0001 started] Result will be available when complete.`，然后**永远等不到结果**，也不知道失败了；
- 异常被线程静默吞掉，终端上什么都看不到。

`agents/s08_background_tasks.py` 里的 `BackgroundManager._execute` 本来就是用 try/except 处理这种情况的（`status = "error"`），s13 之后的三个模块没有跟上。

### 2. s08 的 `DENY_LIST` 被悄悄削弱

s08 里这段代码标着 `# FROM s04 (unchanged): Hooks`，README 的「相对 s07 的变更」表里也没提权限相关的改动，但实际内容是：

| 模块 | DENY_LIST |
|------|-----------|
| s04 / s05 / s06 / s07 / s20 | `rm -rf /`, `sudo`, `shutdown`, `reboot`, `mkfs`, `dd if=` |
| **s08** | `rm -rf /`, `sudo`, `shutdown` |

复制到 s08 的时候漏了 `reboot`、`mkfs`、`dd if=` 三条，导致这一课的 PreToolUse 权限钩子比它声称继承的版本更弱。

## 改动

- **s13 / s14 / s20**：worker 包 try/except，失败时把任务标成 `failed` 并把错误信息存进结果；`collect_background_results` 改为回收所有非 `running` 的任务，并在通知里输出真实的 `<status>`。成功路径行为不变。
- **s08**：`DENY_LIST` 补回 `reboot`、`mkfs`、`dd if=`，与 s04-s07、s20 对齐。
- **s13 README**（zh / en / ja）：同步正文里嵌的这两段代码。

## 测试

- `tests/test_background_task_failure.py`：让 handler 抛异常，断言任务不会停在 `running`、且会产生一条 `<status>failed</status>` 的通知；同时验证成功路径仍然是 `<status>completed</status>`。三个模块都跑。
- `tests/test_deny_list_consistency.py`：把 s04 的 deny list 作为基线钉住，s04/s05/s06/s07/s08/s20 都必须覆盖，防止以后再复制丢条目。

改动前（新测试跑在旧代码上）：

```
6 failed, 3 passed, 3 subtests passed
SUBFAILED(module='s13') ... test_failing_handler_does_not_leave_task_running_forever
SUBFAILED(module='s14') ... test_failing_handler_does_not_leave_task_running_forever
SUBFAILED(module='s20') ... test_failing_handler_does_not_leave_task_running_forever
SUBFAILED(module='s13') ... test_failure_is_reported_back_to_the_model
SUBFAILED(module='s14') ... test_failure_is_reported_back_to_the_model
SUBFAILED(module='s20') ... test_failure_is_reported_back_to_the_model
```

改动后（全量套件）：

```
28 passed, 45 subtests passed in 0.08s
```