### PR TITLE
docs(env): warn that provider thinking behavior breaks minimal examples

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,6 +21,17 @@ MODEL_ID=claude-sonnet-4-6
 #                   deepseek-v4-flash           flash model           see below
 #
 #  Check provider docs for current availability, pricing, and regional access.
+#
+#  NOTE: Reasoning/thinking behavior varies by provider and is NOT handled by the
+#  minimal teaching examples. A learner who copies certain MODEL_ID lines and runs
+#  a chapter may hit an API error or see the model's raw reasoning leak into output:
+#    - kimi-k2.6        : thinking-native; may reject requests unless a non-thinking
+#                         variant (e.g. kimi-k2.7-code) is used.
+#    - deepseek-v4-*    : thinking ON by default; every turn emits a `thinking` block.
+#    - MiniMax-M2.x     : reasoning can leak as `reasoning_content` unless thinking is
+#                         disabled.
+#    - glm-5.2          : hybrid; works as-is.
+#  For the cleanest run, use claude-sonnet-4-6 (default) or a non-thinking model.
 # =============================================================================
 
 # ---- International ----


### PR DESCRIPTION
## Problem

`.env.example` lists several Anthropic-compatible providers (Kimi, DeepSeek, MiniMax, GLM) but gives no warning that their extended-thinking/reasoning behavior differs from the default `claude-sonnet-4-6` and is **not** handled by the minimal teaching examples.

A learner who uncomments a provider `MODEL_ID` line and runs a chapter can hit one of:
- `kimi-k2.6`: thinking-native → may reject requests unless a non-thinking variant is used.
- `deepseek-v4-*`: thinking ON by default → every turn emits a `thinking` block.
- `MiniMax-M2.x`: reasoning can leak as `reasoning_content` into visible output.
- `glm-5.2`: hybrid, works as-is.

This is tracked in issue #459. The default (`claude-sonnet-4-6`) is fine; the gap is purely a missing note.

## Solution

Add a scoped `NOTE` block inside the existing "Anthropic-compatible providers" section of `.env.example`, documenting the per-provider thinking behavior and recommending the default or a non-thinking model for the cleanest run.

Scope is intentionally doc-only:
- No code changes, no new dependencies, no architecture change.
- The minimal teaching examples deliberately do not handle thinking parameters (a uniform flag would break some providers and a fixed `budget_tokens` would 400 on small `max_tokens` calls), so a doc note is the correct fix per the issue discussion.

## Testing

- Change is restricted to `.env.example` (a commented dotenv template); no executable code is affected.
- `tests/test_chapter_readmes.py` validates chapter `README*.md` files only and does not reference `.env.example`, so this change is outside its scope.
- Verified the edited file parses as valid dotenv comments and the diff is limited to 11 added comment lines in a single file.

AI assistance disclosure: this change was prepared and submitted with the help of an AI agent; I have read and stand behind the change.
