### PR TITLE
docs: clarify provider compatibility limits

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,6 +21,13 @@ MODEL_ID=claude-sonnet-4-6
 #                   deepseek-v4-flash           flash model           see below
 #
 #  Check provider docs for current availability, pricing, and regional access.
+#
+#  NOTE: "Anthropic-compatible" does not guarantee identical model behavior.
+#  Providers may differ in supported parameters, reasoning/thinking defaults,
+#  response content blocks, and tool-use history requirements. These teaching
+#  examples do not normalize provider-specific behavior. Check the provider's
+#  current documentation, or use the default Anthropic setup for the most
+#  predictable course experience.
 # =============================================================================
 
 # ---- International ----


### PR DESCRIPTION
## Summary

- clarify that Anthropic-compatible providers may differ in parameters, reasoning behavior, response blocks, and tool history requirements
- avoid model-specific compatibility claims that become stale
- recommend current provider documentation or the default Anthropic setup for a predictable course experience

## Verification

- `git diff --check`
- verified that active `.env.example` entries remain unchanged

Related to #459